### PR TITLE
refactor: RedisUtil 추상화 및 Swagger @Operation 어노테이션 추가

### DIFF
--- a/src/main/java/com/example/playlist/gemini/controller/GeminiController.java
+++ b/src/main/java/com/example/playlist/gemini/controller/GeminiController.java
@@ -4,6 +4,7 @@ import com.example.playlist.gemini.dto.GeminiResponse;
 import com.example.playlist.gemini.service.GeminiService;
 import com.example.playlist.gemini.dto.GeminiRequest;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -17,6 +18,10 @@ public class GeminiController {
 
     private final GeminiService geminiService;
 
+    @Operation(
+            summary = "AI 플레이리스트 생성",
+            description = "사용자가 입력한 프롬프트를 통해 원하는 플레이리스트를 추천해주는 컨트롤러"
+    )
     @PostMapping("/playlist")
     public GeminiResponse createPlaylist(
             @RequestBody GeminiRequest reqeust

--- a/src/main/java/com/example/playlist/global/RedisUtil.java
+++ b/src/main/java/com/example/playlist/global/RedisUtil.java
@@ -1,0 +1,38 @@
+package com.example.playlist.global;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RedisUtil {
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    public void setData(String key, String value) {
+        stringRedisTemplate.opsForValue().set(key, value);
+    }
+
+    public String getData(String key) {
+        return stringRedisTemplate.opsForValue().get(key);
+    }
+
+    public void deleteData(String key) {
+        stringRedisTemplate.delete(key);
+    }
+
+    public void setDataExpire(String key, String value, long time) {
+        stringRedisTemplate.opsForValue().set(key, value, time, TimeUnit.SECONDS);
+        log.info("Set key={} value={} expire={}s", key, value, time);
+    }
+
+    public Long getExpire(String key, TimeUnit timeUnit) {
+        return stringRedisTemplate.getExpire(key, timeUnit);
+    }
+}
+

--- a/src/main/java/com/example/playlist/playlist/controller/PlaylistController.java
+++ b/src/main/java/com/example/playlist/playlist/controller/PlaylistController.java
@@ -4,6 +4,7 @@ import com.example.playlist.gemini.dto.GeminiRequest;
 import com.example.playlist.playlist.dto.PlaylistResponse;
 import com.example.playlist.playlist.service.PlaylistService;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -17,6 +18,10 @@ public class PlaylistController {
 
     private final PlaylistService playlistService;
 
+    @Operation(
+            summary = "실제 플레이리스트 반환",
+            description = "GEMINI가 추천해준 플레이리스트를 Spotify API를 활용해 검색해주는 컨트롤러"
+    )
     @PostMapping
     public PlaylistResponse createPlaylist(
             @RequestBody GeminiRequest geminiRequest

--- a/src/main/java/com/example/playlist/smtp/controller/MailController.java
+++ b/src/main/java/com/example/playlist/smtp/controller/MailController.java
@@ -7,6 +7,7 @@ import com.example.playlist.smtp.dto.MailVerificationRequest;
 import com.example.playlist.smtp.exception.MailErrorCode;
 import com.example.playlist.smtp.exception.MailSuccessCode;
 import com.example.playlist.smtp.service.MailService;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.mail.MessagingException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +25,10 @@ public class MailController {
 
     private final MailService mailService;
 
+    @Operation(
+            summary = "메일 전송",
+            description = "인증 메일을 전송하는 컨트롤러"
+    )
     @PostMapping("/send")
     public ResponseEntity<SuccessResponse> sendMail(@RequestBody @Valid MailRequest request) throws MessagingException {
         mailService.sendCertificationMail(request);
@@ -32,6 +37,10 @@ public class MailController {
                 .body(SuccessResponse.of(MailSuccessCode.MAIL_SUCCESS_SEND));
     }
 
+    @Operation(
+            summary = "메일 검증",
+            description = "이메일 인증을 위해 보낸 코드를 검증하는 컨트롤러"
+    )
     @PostMapping("/verify")
     public ResponseEntity<?> verifyCode(@RequestBody @Valid MailVerificationRequest request) {
         MailErrorCode mailErrorCode = mailService.verifyCode(request);

--- a/src/main/java/com/example/playlist/smtp/service/MailService.java
+++ b/src/main/java/com/example/playlist/smtp/service/MailService.java
@@ -1,5 +1,6 @@
 package com.example.playlist.smtp.service;
 
+import com.example.playlist.global.RedisUtil;
 import com.example.playlist.smtp.dto.MailRequest;
 import com.example.playlist.smtp.dto.MailVerificationRequest;
 import com.example.playlist.smtp.exception.MailErrorCode;
@@ -8,6 +9,7 @@ import jakarta.mail.MessagingException;
 import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.mail.MailException;
@@ -20,16 +22,15 @@ import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class MailService {
 
     private final JavaMailSender mailSender;
-    private final RedisTemplate<String, String> redisTemplate;
+    private final RedisUtil redisUtil;
 
     @Value("${spring.mail.username}")
     String sendEmail;
 
-    private static final String MAIL_PREFIX = "mail:";
-    private static final long TTL_MINUTES = 5;
 
     public MimeMessage createCodeEmail(String email, String code) throws MessagingException {
         try {
@@ -40,33 +41,32 @@ public class MailService {
             mimeMessage.setFrom(sendEmail);
             return mimeMessage;
         } catch (MessagingException e) {
-            throw new MailSendException("이메일 생성 중 오류 발생");
+            throw new MailSendException("이메일 생성 중 오류 발생하였습니다. 다시 시도해주세요!");
         }
     }
 
     public void sendMail(MimeMessage email) {
-        try {
-            mailSender.send(email);
-        } catch (MailException e) {
-            e.printStackTrace();
-            throw new IllegalArgumentException();
-        }
+        try { mailSender.send(email);}
+        catch (MailException e) {log.error("메일 전송 실패", e);}
     }
 
     private String createAuthNumber() {
         return UUID.randomUUID().toString().substring(0, 6);
     }
 
-    public void sendCertificationMail(MailRequest mailRequest) throws MessagingException {
+    public String sendCertificationMail(MailRequest mailRequest) throws MessagingException {
         String code = createAuthNumber();
+
         sendMail(createCodeEmail(mailRequest.getEmail(), code));
-        redisTemplate.opsForValue().set(MAIL_PREFIX + mailRequest.getEmail(), code, TTL_MINUTES, TimeUnit.SECONDS);
+        redisUtil.setDataExpire(mailRequest.getEmail(), code, 180L);
+
+        return code;
     }
 
     //TODO : redis 활용하여, verify Key를 활용해 회원가입 할 때 이 이메일에 존재하는지 여부 체크
     public MailErrorCode verifyCode(MailVerificationRequest request) {
-        String savedCode = redisTemplate.opsForValue().get(MAIL_PREFIX + request.getEmail());
-        Long ttl = redisTemplate.getExpire(request.getEmail(), TimeUnit.SECONDS);
+        String savedCode = redisUtil.getData(request.getEmail());
+        Long ttl = redisUtil.getExpire(request.getEmail(), TimeUnit.SECONDS);
 
         if (savedCode == null || ttl == -2) {
             return MailErrorCode.CODE_INVALID;
@@ -74,7 +74,9 @@ public class MailService {
             return MailErrorCode.CODE_IS_NOT_CORRECT;
         }
 
-        redisTemplate.delete(MAIL_PREFIX + request.getEmail());
+        redisUtil.setDataExpire("verified: " + request.getEmail(), request.getEmail(), 600);
+        redisUtil.deleteData(request.getEmail());
+
         return MailErrorCode.CODE_OK;
     }
 }


### PR DESCRIPTION
## Summary

- **RedisUtil 컴포넌트 추가**: `StringRedisTemplate`을 래핑한 유틸 클래스로, `setData` / `getData` / `deleteData` / `setDataExpire` / `getExpire` 메서드 제공
- **MailService 리팩토링**: 기존 `RedisTemplate` 직접 사용에서 `RedisUtil`로 교체, 인증 코드 TTL 180초 적용, 인증 완료 후 `verified:` 키 별도 저장(TTL 600초), `@Slf4j` 로깅 추가
- **Swagger 문서화**: `GeminiController`, `PlaylistController`, `MailController`에 `@Operation` 어노테이션(summary/description) 추가

## Test plan

- [ ] 이메일 인증 코드 발송 후 Redis에 키가 TTL 180초로 저장되는지 확인
- [ ] 올바른 코드 입력 시 `verified:` 키가 TTL 600초로 저장되고 원래 코드 키가 삭제되는지 확인
- [ ] 만료된 코드 입력 시 `CODE_INVALID` 응답 반환 확인
- [ ] Swagger UI(`/swagger-ui.html`)에서 각 엔드포인트 summary/description 노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)