### PR TITLE
feat: Google/Spotify 소셜 로그인 + 계정 통합 + 추가정보 입력 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
 
 	// Spotify OAuth2 + Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
-//	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	// WebClient (Spotify API HTTP 통신)
     implementation 'org.springframework:spring-webflux'
 	// JSON 파싱 (Gemini 응답 처리)

--- a/src/main/java/com/example/playlist/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/playlist/global/config/SecurityConfig.java
@@ -1,7 +1,11 @@
 package com.example.playlist.global.config;
 
 import com.example.playlist.global.filter.JwtFilter;
+import com.example.playlist.global.oauth2.HttpCookieOAuth2AuthorizationRequestRepository;
 import com.example.playlist.global.util.JwtUtil;
+import com.example.playlist.member.oauth2.CustomOAuth2UserService;
+import com.example.playlist.member.oauth2.OAuth2FailureHandler;
+import com.example.playlist.member.oauth2.OAuth2SuccessHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -23,6 +27,10 @@ import java.util.List;
 public class SecurityConfig {
 
     private final JwtUtil jwtUtil;
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
+    private final OAuth2FailureHandler oAuth2FailureHandler;
+    private final HttpCookieOAuth2AuthorizationRequestRepository authorizationRequestRepository;
 
     @Bean
     public BCryptPasswordEncoder bCryptPasswordEncoder() {
@@ -42,12 +50,23 @@ public class SecurityConfig {
                         .requestMatchers("/mail/**").permitAll()
                         .requestMatchers("/members/join").permitAll()
                         .requestMatchers("/members/login").permitAll()
+                        .requestMatchers("/members/profile/complete").permitAll()
+                        .requestMatchers("/oauth2/**", "/login/oauth2/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .anyRequest().authenticated()
                 );
         http
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+        http
+                .oauth2Login(oauth2 -> oauth2
+                        .authorizationEndpoint(auth -> auth
+                                .authorizationRequestRepository(authorizationRequestRepository))
+                        .userInfoEndpoint(userInfo -> userInfo
+                                .userService(customOAuth2UserService))
+                        .successHandler(oAuth2SuccessHandler)
+                        .failureHandler(oAuth2FailureHandler)
+                );
         http
                 .addFilterBefore(new JwtFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/com/example/playlist/global/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/example/playlist/global/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -1,0 +1,51 @@
+package com.example.playlist.global.oauth2;
+
+import com.example.playlist.global.util.CookieUtils;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+
+/**
+ * STATELESS 환경에서 OAuth2 인증 요청 정보를 세션 대신 쿠키에 저장.
+ *
+ * 흐름:
+ * 1. 소셜 로그인 시작 → OAuth2AuthorizationRequest를 직렬화해 쿠키에 저장
+ * 2. 소셜 서버 콜백 → 쿠키에서 역직렬화해 인증 요청 복원 → state 검증
+ * 3. 로그인 완료 → 쿠키 삭제
+ */
+@Component
+public class HttpCookieOAuth2AuthorizationRequestRepository
+        implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+
+    private static final String COOKIE_NAME = "oauth2_auth_request";
+    private static final int COOKIE_EXPIRE_SECONDS = 180; // 3분
+
+    @Override
+    public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+        return CookieUtils.getCookie(request, COOKIE_NAME)
+                .map(cookie -> CookieUtils.deserialize(cookie, OAuth2AuthorizationRequest.class))
+                .orElse(null);
+    }
+
+    @Override
+    public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest,
+                                         HttpServletRequest request,
+                                         HttpServletResponse response) {
+        if (authorizationRequest == null) {
+            CookieUtils.deleteCookie(request, response, COOKIE_NAME);
+            return;
+        }
+        CookieUtils.addCookie(response, COOKIE_NAME,
+                CookieUtils.serialize(authorizationRequest), COOKIE_EXPIRE_SECONDS);
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request,
+                                                                  HttpServletResponse response) {
+        OAuth2AuthorizationRequest authorizationRequest = loadAuthorizationRequest(request);
+        CookieUtils.deleteCookie(request, response, COOKIE_NAME);
+        return authorizationRequest;
+    }
+}

--- a/src/main/java/com/example/playlist/global/util/CookieUtils.java
+++ b/src/main/java/com/example/playlist/global/util/CookieUtils.java
@@ -1,0 +1,63 @@
+package com.example.playlist.global.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.*;
+import java.util.Base64;
+import java.util.Optional;
+
+public class CookieUtils {
+
+    public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) return Optional.empty();
+        for (Cookie cookie : cookies) {
+            if (cookie.getName().equals(name)) return Optional.of(cookie);
+        }
+        return Optional.empty();
+    }
+
+    public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(maxAge);
+        response.addCookie(cookie);
+    }
+
+    public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) return;
+        for (Cookie cookie : cookies) {
+            if (cookie.getName().equals(name)) {
+                cookie.setValue("");
+                cookie.setPath("/");
+                cookie.setMaxAge(0);
+                response.addCookie(cookie);
+            }
+        }
+    }
+
+    public static String serialize(Object object) {
+        try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+             ObjectOutputStream oos = new ObjectOutputStream(bos)) {
+            oos.writeObject(object);
+            return Base64.getUrlEncoder().encodeToString(bos.toByteArray());
+        } catch (IOException e) {
+            throw new RuntimeException("쿠키 직렬화 실패", e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> T deserialize(Cookie cookie, Class<T> cls) {
+        try (ByteArrayInputStream bis = new ByteArrayInputStream(
+                Base64.getUrlDecoder().decode(cookie.getValue()));
+             ObjectInputStream ois = new ObjectInputStream(bis)) {
+            return cls.cast(ois.readObject());
+        } catch (IOException | ClassNotFoundException e) {
+            throw new RuntimeException("쿠키 역직렬화 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/example/playlist/global/util/JwtUtil.java
+++ b/src/main/java/com/example/playlist/global/util/JwtUtil.java
@@ -61,6 +61,46 @@ public class JwtUtil {
                 .compact();
     }
 
+    /** 소셜 신규 회원 - 추가정보 입력 전까지만 유효한 10분짜리 임시 토큰 */
+    public String createTempToken(Long memberId) {
+        Date now = new Date();
+        return Jwts.builder()
+                .subject("TempToken")
+                .claim("memberId", memberId)
+                .claim("type", "TEMP")
+                .issuedAt(now)
+                .expiration(new Date(now.getTime() + 10 * 60 * 1000L))
+                .signWith(getKey())
+                .compact();
+    }
+
+    public void sendTempToken(HttpServletResponse response, String tempToken) {
+        Cookie tempCookie = new Cookie("tempToken", tempToken);
+        tempCookie.setHttpOnly(true);
+        tempCookie.setPath("/");
+        tempCookie.setMaxAge(10 * 60);
+        response.addCookie(tempCookie);
+        log.info("TempToken 쿠키 설정 완료");
+    }
+
+    public Optional<Long> extractMemberIdFromTempToken(HttpServletRequest request) {
+        if (request.getCookies() == null) return Optional.empty();
+        return Arrays.stream(request.getCookies())
+                .filter(c -> "tempToken".equals(c.getName()))
+                .map(Cookie::getValue)
+                .filter(this::isTokenValid)
+                .findFirst()
+                .flatMap(token -> {
+                    try {
+                        Claims claims = parseClaims(token);
+                        if (!"TEMP".equals(claims.get("type", String.class))) return Optional.empty();
+                        return Optional.ofNullable(claims.get("memberId", Long.class));
+                    } catch (Exception e) {
+                        return Optional.empty();
+                    }
+                });
+    }
+
     public void sendAccessAndRefreshToken(HttpServletResponse response, String accessToken, String refreshToken) {
         Cookie accessCookie = new Cookie("accessToken", accessToken);
         accessCookie.setHttpOnly(true);
@@ -143,7 +183,7 @@ public class JwtUtil {
     }
 
     @Transactional
-    public void logout(HttpServletRequest request, String loginId) {
+    public void logout(HttpServletRequest request, HttpServletResponse response, String loginId) {
         extractAccessToken(request).ifPresent(accessToken -> {
             try {
                 Date expiration = parseClaims(accessToken).getExpiration();
@@ -156,6 +196,17 @@ public class JwtUtil {
                 log.warn("로그아웃 처리 중 토큰 파싱 실패: {}", e.getMessage());
             }
         });
+        // 브라우저 쿠키 삭제
+        clearCookie(response, "accessToken");
+        clearCookie(response, "refreshToken");
+    }
+
+    private void clearCookie(HttpServletResponse response, String cookieName) {
+        Cookie cookie = new Cookie(cookieName, null);
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(0);
+        response.addCookie(cookie);
     }
 
     private Claims parseClaims(String token) {

--- a/src/main/java/com/example/playlist/mail/exception/MailErrorCode.java
+++ b/src/main/java/com/example/playlist/mail/exception/MailErrorCode.java
@@ -10,7 +10,8 @@ public enum MailErrorCode implements ErrorCode {
     MAIL_ERROR_CODE(HttpStatus.BAD_REQUEST, "이메일 오류 발생"),
     CODE_INVALID(HttpStatus.BAD_REQUEST, "인증코드 만료되었습니다."),
     CODE_IS_NOT_CORRECT(HttpStatus.BAD_REQUEST, "인증번호가 일치하지 않습니다."),
-    CODE_OK(HttpStatus.OK, "인증 성공");
+    CODE_OK(HttpStatus.OK, "인증 성공"),
+    EMAIL_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 가입되어있는 이메일입니다. 해당 이메일로 로그인해주세요.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/example/playlist/mail/service/MailService.java
+++ b/src/main/java/com/example/playlist/mail/service/MailService.java
@@ -1,16 +1,17 @@
-package com.example.playlist.smtp.service;
+package com.example.playlist.mail.service;
 
 import com.example.playlist.global.util.RedisUtil;
-import com.example.playlist.smtp.dto.MailRequest;
-import com.example.playlist.smtp.dto.MailVerificationRequest;
-import com.example.playlist.smtp.exception.MailErrorCode;
+import com.example.playlist.mail.dto.MailRequest;
+import com.example.playlist.mail.dto.MailVerificationRequest;
+import com.example.playlist.mail.exception.MailErrorCode;
+import com.example.playlist.mail.exception.MailException;
+import com.example.playlist.member.repository.MemberMapper;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.mail.MailException;
 import org.springframework.mail.MailSendException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
@@ -25,6 +26,7 @@ public class MailService {
 
     private final JavaMailSender mailSender;
     private final RedisUtil redisUtil;
+    private final MemberMapper memberMapper;
 
     @Value("${spring.mail.username}")
     String sendEmail;
@@ -53,8 +55,11 @@ public class MailService {
     }
 
     public String sendCertificationMail(MailRequest mailRequest) throws MessagingException {
-        String code = createAuthNumber();
+        memberMapper.findByEmail(mailRequest.getEmail()).ifPresent(member -> {
+            throw new MailException(MailErrorCode.EMAIL_ALREADY_EXIST);
+        });
 
+        String code = createAuthNumber();
         sendMail(createCodeEmail(mailRequest.getEmail(), code));
         redisUtil.setDataExpire(mailRequest.getEmail(), code, 180L);
 

--- a/src/main/java/com/example/playlist/member/controller/MemberController.java
+++ b/src/main/java/com/example/playlist/member/controller/MemberController.java
@@ -3,6 +3,8 @@ package com.example.playlist.member.controller;
 import com.example.playlist.global.success.SuccessResponse;
 import com.example.playlist.member.dto.JoinRequest;
 import com.example.playlist.member.dto.LoginRequest;
+import com.example.playlist.member.dto.MemberInfoResponse;
+import com.example.playlist.member.dto.SocialProfileCompleteRequest;
 import com.example.playlist.member.exception.MemberSuccessCode;
 import com.example.playlist.member.service.MemberService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -13,10 +15,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
 
 @RestController
 @RequestMapping("/members")
@@ -48,15 +48,44 @@ public class MemberController {
                 .body(SuccessResponse.of(MemberSuccessCode.LOGIN_SUCCESS));
     }
 
+    @GetMapping("/me")
+    public ResponseEntity<SuccessResponse<MemberInfoResponse>> getMe(
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        MemberInfoResponse info = memberService.getMe(userDetails.getUsername());
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(SuccessResponse.of(MemberSuccessCode.LOGIN_SUCCESS, info));
+    }
+
     @PostMapping("/logout")
     public ResponseEntity<SuccessResponse> logout(
             HttpServletRequest request,
+            HttpServletResponse response,
             @AuthenticationPrincipal UserDetails userDetails
     ) {
-        memberService.logout(request, userDetails.getUsername());
+        memberService.logout(request, response, userDetails.getUsername());
 
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(SuccessResponse.of(MemberSuccessCode.LOGOUT_SUCCESS));
+    }
+
+    /**
+     * 소셜 신규 회원 추가정보 입력 완료.
+     * tempToken 쿠키가 필요하며, 성공 시 정식 AccessToken/RefreshToken이 발급된다.
+     */
+    @PostMapping("/profile/complete")
+    public ResponseEntity<SuccessResponse> completeProfile(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            @RequestBody @Valid SocialProfileCompleteRequest profileRequest
+    ) {
+        memberService.completeProfile(request, response, profileRequest);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(SuccessResponse.of(MemberSuccessCode.PROFILE_COMPLETE_SUCCESS));
     }
 }

--- a/src/main/java/com/example/playlist/member/dto/MemberInfoResponse.java
+++ b/src/main/java/com/example/playlist/member/dto/MemberInfoResponse.java
@@ -1,0 +1,31 @@
+package com.example.playlist.member.dto;
+
+import com.example.playlist.member.entity.Gender;
+import com.example.playlist.member.entity.Member;
+import com.example.playlist.member.entity.Provider;
+
+public record MemberInfoResponse(
+        Long id,
+        String loginId,
+        String email,
+        String name,
+        String nickname,
+        Gender gender,
+        Integer age,
+        Provider provider,
+        boolean profileComplete
+) {
+    public static MemberInfoResponse from(Member member) {
+        return new MemberInfoResponse(
+                member.getId(),
+                member.getLoginId(),
+                member.getEmail(),
+                member.getName(),
+                member.getNickname(),
+                member.getGender(),
+                member.getAge(),
+                member.getProvider(),
+                member.isProfileComplete()
+        );
+    }
+}

--- a/src/main/java/com/example/playlist/member/dto/SocialProfileCompleteRequest.java
+++ b/src/main/java/com/example/playlist/member/dto/SocialProfileCompleteRequest.java
@@ -1,0 +1,24 @@
+package com.example.playlist.member.dto;
+
+import com.example.playlist.member.entity.Gender;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SocialProfileCompleteRequest {
+
+    @NotBlank(message = "닉네임은 필수로 입력하여야 합니다.")
+    private String nickname;
+
+    @NotNull(message = "성별은 필수로 입력하여야 합니다.")
+    private Gender gender;
+
+    @Min(value = 1, message = "나이는 1 이상이어야 합니다.")
+    private int age;
+}

--- a/src/main/java/com/example/playlist/member/entity/Member.java
+++ b/src/main/java/com/example/playlist/member/entity/Member.java
@@ -16,13 +16,14 @@ public class Member {
     private String nickname;
     private String password;
     private Gender gender;
-    private int age;
+    private Integer age;
     private Provider provider;
+    private boolean profileComplete;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private boolean isDeleted;
 
-    public static Member createMember(String loginId, String email,String password, String nickname, String name, Gender gender, int age) {
+    public static Member createMember(String loginId, String email, String password, String nickname, String name, Gender gender, int age) {
         return Member.builder()
                 .loginId(loginId)
                 .email(email)
@@ -31,6 +32,20 @@ public class Member {
                 .name(name)
                 .gender(gender)
                 .age(age)
+                .provider(Provider.LOCAL)
+                .profileComplete(true)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+    }
+
+    public static Member createSocialMember(String loginId, String email, String name, Provider provider) {
+        return Member.builder()
+                .loginId(loginId)
+                .email(email)
+                .name(name)
+                .provider(provider)
+                .profileComplete(false)
                 .createdAt(LocalDateTime.now())
                 .updatedAt(LocalDateTime.now())
                 .build();

--- a/src/main/java/com/example/playlist/member/entity/MemberSocial.java
+++ b/src/main/java/com/example/playlist/member/entity/MemberSocial.java
@@ -1,0 +1,29 @@
+package com.example.playlist.member.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberSocial {
+    private Long id;
+    private Long memberId;
+    private String provider;
+    private String providerId;
+    private LocalDateTime createdAt;
+
+    public static MemberSocial of(Long memberId, Provider provider, String providerId) {
+        return MemberSocial.builder()
+                .memberId(memberId)
+                .provider(provider.name())
+                .providerId(providerId)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/com/example/playlist/member/entity/Provider.java
+++ b/src/main/java/com/example/playlist/member/entity/Provider.java
@@ -4,5 +4,5 @@ public enum Provider {
     LOCAL,
     NAVER,
     GOOGLE,
-    KAKAO
+    SPOTIFY
 }

--- a/src/main/java/com/example/playlist/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/example/playlist/member/exception/MemberErrorCode.java
@@ -12,7 +12,8 @@ public enum MemberErrorCode implements ErrorCode {
     ACCESS_EXCEPTION(HttpStatus.BAD_REQUEST, "액세스 토큰이 없습니다."),
     MAIL_VERIFIED_FAILED(HttpStatus.BAD_REQUEST, "메일 인증이 완료되지않았습니다."),
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
-    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 올바르지 않습니다.");
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 올바르지 않습니다."),
+    INVALID_TEMP_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 임시 토큰입니다. 소셜 로그인을 다시 진행해주세요.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/example/playlist/member/exception/MemberSuccessCode.java
+++ b/src/main/java/com/example/playlist/member/exception/MemberSuccessCode.java
@@ -9,7 +9,8 @@ public enum MemberSuccessCode implements SuccessCode {
 
     LOGIN_SUCCESS(HttpStatus.OK, "로그인이 성공적으로 완료되었습니다."),
     MEMBER_SUCCESS_SIGNUP(HttpStatus.OK, "회원가입이 성공적으로 완료되었습니다."),
-    LOGOUT_SUCCESS(HttpStatus.OK, "로그아웃이 성공적으로 완료되었습니다.");
+    LOGOUT_SUCCESS(HttpStatus.OK, "로그아웃이 성공적으로 완료되었습니다."),
+    PROFILE_COMPLETE_SUCCESS(HttpStatus.OK, "추가 정보 입력이 완료되었습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/example/playlist/member/oauth2/CustomOAuth2User.java
+++ b/src/main/java/com/example/playlist/member/oauth2/CustomOAuth2User.java
@@ -1,0 +1,50 @@
+package com.example.playlist.member.oauth2;
+
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * OAuth2 로그인 후 SecurityContext에 담길 사용자 객체.
+ * loginId, memberId, profileComplete 정보를 추가로 보유한다.
+ */
+@Getter
+public class CustomOAuth2User implements OAuth2User {
+
+    private final Map<String, Object> attributes;
+    private final String nameAttributeKey;
+    private final String loginId;
+    private final Long memberId;
+    private final boolean profileComplete;
+
+    public CustomOAuth2User(Map<String, Object> attributes,
+                            String nameAttributeKey,
+                            String loginId,
+                            Long memberId,
+                            boolean profileComplete) {
+        this.attributes = attributes;
+        this.nameAttributeKey = nameAttributeKey;
+        this.loginId = loginId;
+        this.memberId = memberId;
+        this.profileComplete = profileComplete;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String getName() {
+        return attributes.get(nameAttributeKey).toString();
+    }
+}

--- a/src/main/java/com/example/playlist/member/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/playlist/member/oauth2/CustomOAuth2UserService.java
@@ -1,0 +1,97 @@
+package com.example.playlist.member.oauth2;
+
+import com.example.playlist.member.entity.Member;
+import com.example.playlist.member.entity.MemberSocial;
+import com.example.playlist.member.entity.Provider;
+import com.example.playlist.member.repository.MemberMapper;
+import com.example.playlist.member.repository.MemberSocialMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Google / Spotify OAuth2 콜백을 단일 서비스에서 처리.
+ * - Google : scope에 openid 미포함 → 일반 OAuth2UserService로 진입
+ * - Spotify: 커스텀 provider 등록
+ *
+ * 처리 순서:
+ * 1. member_social (provider + providerId) 조회 → 기존 소셜 계정이면 바로 로그인
+ * 2. member (email) 조회 → 다른 경로로 가입된 계정이면 소셜 계정 연결 (계정 통합)
+ * 3. 둘 다 없으면 신규 member + member_social 생성, profileComplete=false
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final MemberMapper memberMapper;
+    private final MemberSocialMapper memberSocialMapper;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oauth2User = super.loadUser(userRequest);
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        Map<String, Object> attributes = oauth2User.getAttributes();
+
+        OAuthAttributes oAuthAttributes = OAuthAttributes.of(registrationId, attributes);
+
+        Member member = processOAuth2User(oAuthAttributes);
+
+        return new CustomOAuth2User(
+                attributes,
+                oAuthAttributes.getNameAttributeKey(),
+                member.getLoginId(),
+                member.getId(),
+                member.isProfileComplete()
+        );
+    }
+
+    private Member processOAuth2User(OAuthAttributes attrs) {
+        String provider = attrs.getProvider().name();
+        String providerId = attrs.getProviderId();
+        String email = attrs.getEmail();
+        String name = attrs.getName();
+
+        // 1. member_social에 이미 등록된 소셜 계정인지 확인
+        Optional<MemberSocial> existingSocial = memberSocialMapper.findByProviderAndProviderId(provider, providerId);
+        if (existingSocial.isPresent()) {
+            Member member = memberMapper.findById(existingSocial.get().getMemberId())
+                    .orElseThrow(() -> new OAuth2AuthenticationException("회원 정보를 찾을 수 없습니다."));
+            log.info("[OAuth2] 기존 소셜 계정 로그인 - provider={}, email={}", provider, email);
+            return member;
+        }
+
+        // 2. 동일 이메일로 가입된 계정이 있으면 소셜 계정 연결 (계정 통합)
+        Optional<Member> existingMember = memberMapper.findByEmail(email);
+        if (existingMember.isPresent()) {
+            Member member = existingMember.get();
+            MemberSocial memberSocial = MemberSocial.of(member.getId(), attrs.getProvider(), providerId);
+            memberSocialMapper.save(memberSocial);
+            log.info("[OAuth2] 기존 회원에 소셜 계정 연결(통합) - provider={}, email={}", provider, email);
+            return member;
+        }
+
+        // 3. 신규 회원 생성
+        String loginId = attrs.getProvider().name().toLowerCase() + "_" + providerId;
+        Member newMember = Member.createSocialMember(loginId, email, name, attrs.getProvider());
+        memberMapper.save(newMember);
+
+        // 저장 후 ID가 채워진 member 다시 조회
+        Member savedMember = memberMapper.findByLoginId(loginId)
+                .orElseThrow(() -> new OAuth2AuthenticationException("회원 저장에 실패했습니다."));
+
+        MemberSocial memberSocial = MemberSocial.of(savedMember.getId(), attrs.getProvider(), providerId);
+        memberSocialMapper.save(memberSocial);
+
+        log.info("[OAuth2] 신규 소셜 회원 생성 - provider={}, email={}", provider, email);
+        return savedMember;
+    }
+}

--- a/src/main/java/com/example/playlist/member/oauth2/OAuth2FailureHandler.java
+++ b/src/main/java/com/example/playlist/member/oauth2/OAuth2FailureHandler.java
@@ -1,0 +1,30 @@
+package com.example.playlist.member.oauth2;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+/**
+ * OAuth2 로그인 실패 시 프론트 에러 페이지로 리다이렉트
+ */
+@Slf4j
+@Component
+public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    @Value("${app.frontend-url}")
+    private String frontendUrl;
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException {
+        log.error("[OAuth2] 로그인 실패: {}", exception.getMessage());
+        getRedirectStrategy().sendRedirect(request, response, frontendUrl + "/login?error=social");
+    }
+}

--- a/src/main/java/com/example/playlist/member/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/example/playlist/member/oauth2/OAuth2SuccessHandler.java
@@ -1,0 +1,55 @@
+package com.example.playlist.member.oauth2;
+
+import com.example.playlist.global.util.JwtUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+/**
+ * OAuth2 로그인 성공 후처리:
+ * - profileComplete=true  → AccessToken + RefreshToken 발급 후 프론트 메인 페이지로 리다이렉트
+ * - profileComplete=false → TempToken 발급 후 프론트 추가정보 입력 페이지로 리다이렉트
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JwtUtil jwtUtil;
+
+    @Value("${app.frontend-url}")
+    private String frontendUrl;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        Authentication authentication) throws IOException {
+        CustomOAuth2User oauth2User = (CustomOAuth2User) authentication.getPrincipal();
+
+        if (!oauth2User.isProfileComplete()) {
+            // 신규 소셜 회원 → 추가정보 입력 필요
+            String tempToken = jwtUtil.createTempToken(oauth2User.getMemberId());
+            jwtUtil.sendTempToken(response, tempToken);
+            log.info("[OAuth2] 추가정보 입력 필요 - memberId={}", oauth2User.getMemberId());
+            getRedirectStrategy().sendRedirect(request, response, frontendUrl + "/profile/complete");
+            return;
+        }
+
+        // 기존 회원 → 정상 토큰 발급
+        String loginId = oauth2User.getLoginId();
+        String accessToken = jwtUtil.createAccessToken(loginId);
+        String refreshToken = jwtUtil.createRefreshToken(loginId);
+        jwtUtil.saveRefreshToken(loginId, refreshToken);
+        jwtUtil.sendAccessAndRefreshToken(response, accessToken, refreshToken);
+
+        log.info("[OAuth2] 로그인 성공 - loginId={}", loginId);
+        getRedirectStrategy().sendRedirect(request, response, frontendUrl);
+    }
+}

--- a/src/main/java/com/example/playlist/member/oauth2/OAuthAttributes.java
+++ b/src/main/java/com/example/playlist/member/oauth2/OAuthAttributes.java
@@ -1,0 +1,57 @@
+package com.example.playlist.member.oauth2;
+
+import com.example.playlist.member.entity.Provider;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+/**
+ * Google / Spotify OAuth2 응답에서 공통 필드를 추출하는 VO.
+ */
+@Getter
+@Builder
+public class OAuthAttributes {
+
+    private Provider provider;
+    private String providerId;
+    private String email;
+    private String name;
+    private String nameAttributeKey;
+
+    public static OAuthAttributes of(String registrationId, Map<String, Object> attributes) {
+        return switch (registrationId.toLowerCase()) {
+            case "google" -> ofGoogle(attributes);
+            case "spotify" -> ofSpotify(attributes);
+            default -> throw new IllegalArgumentException("지원하지 않는 소셜 로그인입니다: " + registrationId);
+        };
+    }
+
+    /**
+     * Google OAuth2 (openid 스코프 미포함 → userinfo 엔드포인트 응답)
+     * 주요 필드: sub, email, name, picture
+     */
+    private static OAuthAttributes ofGoogle(Map<String, Object> attributes) {
+        return OAuthAttributes.builder()
+                .provider(Provider.GOOGLE)
+                .providerId(attributes.get("sub").toString())
+                .email(attributes.get("email").toString())
+                .name(attributes.getOrDefault("name", "").toString())
+                .nameAttributeKey("sub")
+                .build();
+    }
+
+    /**
+     * Spotify OAuth2
+     * 주요 필드: id, email, display_name
+     */
+    private static OAuthAttributes ofSpotify(Map<String, Object> attributes) {
+        return OAuthAttributes.builder()
+                .provider(Provider.SPOTIFY)
+                .providerId(attributes.get("id").toString())
+                .email(attributes.getOrDefault("email", "").toString())
+                .name(attributes.getOrDefault("display_name", "").toString())
+                .nameAttributeKey("id")
+                .build();
+    }
+}

--- a/src/main/java/com/example/playlist/member/repository/MemberMapper.java
+++ b/src/main/java/com/example/playlist/member/repository/MemberMapper.java
@@ -1,15 +1,21 @@
 package com.example.playlist.member.repository;
 
+import com.example.playlist.member.entity.Gender;
 import com.example.playlist.member.entity.Member;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.Optional;
 
 @Mapper
 public interface MemberMapper {
 
-    Member findById(Long memberId);
+    Optional<Member> findById(Long memberId);
     Optional<Member> findByEmail(String email);
     void save(Member member);
     Optional<Member> findByLoginId(String loginId);
+    void updateProfile(@Param("memberId") Long memberId,
+                       @Param("nickname") String nickname,
+                       @Param("age") int age,
+                       @Param("gender") Gender gender);
 }

--- a/src/main/java/com/example/playlist/member/repository/MemberSocialMapper.java
+++ b/src/main/java/com/example/playlist/member/repository/MemberSocialMapper.java
@@ -1,0 +1,15 @@
+package com.example.playlist.member.repository;
+
+import com.example.playlist.member.entity.MemberSocial;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.Optional;
+
+@Mapper
+public interface MemberSocialMapper {
+
+    Optional<MemberSocial> findByProviderAndProviderId(@Param("provider") String provider,
+                                                       @Param("providerId") String providerId);
+    void save(MemberSocial memberSocial);
+}

--- a/src/main/java/com/example/playlist/member/service/MemberService.java
+++ b/src/main/java/com/example/playlist/member/service/MemberService.java
@@ -4,6 +4,8 @@ import com.example.playlist.global.util.JwtUtil;
 import com.example.playlist.global.util.RedisUtil;
 import com.example.playlist.member.dto.JoinRequest;
 import com.example.playlist.member.dto.JoinResponse;
+import com.example.playlist.member.dto.MemberInfoResponse;
+import com.example.playlist.member.dto.SocialProfileCompleteRequest;
 import com.example.playlist.member.entity.Member;
 import com.example.playlist.member.exception.MemberErrorCode;
 import com.example.playlist.member.exception.MemberException;
@@ -68,8 +70,35 @@ public class MemberService implements UserDetailsService {
         jwtUtil.sendAccessAndRefreshToken(response, accessToken, refreshToken);
     }
 
-    public void logout(HttpServletRequest request, String loginId) {
-        jwtUtil.logout(request, loginId);
+    public void logout(HttpServletRequest request, HttpServletResponse response, String loginId) {
+        jwtUtil.logout(request, response, loginId);
+    }
+
+    public MemberInfoResponse getMe(String loginId) {
+        Member member = memberMapper.findByLoginId(loginId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+        return MemberInfoResponse.from(member);
+    }
+
+    /**
+     * 소셜 신규 회원 추가정보 입력 완료.
+     * tempToken 쿠키를 검증 후 nickname/age/gender 저장 → 정식 토큰 발급.
+     */
+    public void completeProfile(HttpServletRequest request,
+                                HttpServletResponse response,
+                                SocialProfileCompleteRequest profileRequest) {
+        Long memberId = jwtUtil.extractMemberIdFromTempToken(request)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.INVALID_TEMP_TOKEN));
+
+        memberMapper.updateProfile(memberId, profileRequest.getNickname(), profileRequest.getAge(), profileRequest.getGender());
+
+        Member member = memberMapper.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        String accessToken = jwtUtil.createAccessToken(member.getLoginId());
+        String refreshToken = jwtUtil.createRefreshToken(member.getLoginId());
+        jwtUtil.saveRefreshToken(member.getLoginId(), refreshToken);
+        jwtUtil.sendAccessAndRefreshToken(response, accessToken, refreshToken);
     }
 
     @Override

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,25 +44,29 @@ spring:
     refresh-token-expiration: 1209600   # 14일 (초)
 
 
-#  security:
-#    oauth2:
-#      client:
-#        registration:
-#          spotify:
-#            client-id: ${SPOTIFY_CLIENT_ID}
-#            client-secret: ${SPOTIFY_CLIENT_SECRET}
-#            redirect-uri: ${SPOTIFY_REDIRECT_URI:http://127.0.0.1:8080/login/oauth2/code/spotify}
-#            authorization-grant-type: authorization_code
-#            scope:
-#              - playlist-modify-public
-#              - playlist-modify-private
-#              - user-read-email
-#        provider:
-#          spotify:
-#            authorization-uri: https://accounts.spotify.com/authorize
-#            token-uri: https://accounts.spotify.com/api/token
-#            user-info-uri: https://api.spotify.com/v1/me
-#            user-name-attribute: id
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            redirect-uri: "http://127.0.0.1:8080/api/v1/login/oauth2/code/google"
+            scope: profile,email   # openid 제외 → OIDC 미사용, 단일 CustomOAuth2UserService로 처리
+          spotify:
+            client-id: ${SPOTIFY_CLIENT_ID}
+            client-secret: ${SPOTIFY_CLIENT_SECRET}
+            redirect-uri: "http://127.0.0.1:8080/api/v1/login/oauth2/code/spotify"
+            authorization-grant-type: authorization_code
+            scope:
+              - user-read-email
+              - user-read-private
+        provider:
+          spotify:
+            authorization-uri: https://accounts.spotify.com/authorize
+            token-uri: https://accounts.spotify.com/api/token
+            user-info-uri: https://api.spotify.com/v1/me
+            user-name-attribute: id
 
 mybatis:
   mapper-locations: classpath:mapper/**/*.xml
@@ -80,4 +84,7 @@ swagger:
 spotify:
   client-id: ${SPOTIFY_CLIENT_ID}
   client-secret: ${SPOTIFY_CLIENT_SECRET}
+
+app:
+  frontend-url: ${FRONTEND_URL:http://127.0.0.1:5173}
 

--- a/src/main/resources/mapper/MemberMapper.xml
+++ b/src/main/resources/mapper/MemberMapper.xml
@@ -5,12 +5,12 @@
 <mapper namespace="com.example.playlist.member.repository.MemberMapper">
 
     <insert id="save" useGeneratedKeys="true" keyProperty="id">
-        INSERT INTO member (login_id, email, password, nickname, name, gender, age, created_at, updated_at, is_deleted)
-        VALUES (#{loginId}, #{email}, #{password}, #{nickname}, #{name}, #{gender}, #{age}, #{createdAt}, #{updatedAt}, false)
+        INSERT INTO member (login_id, email, password, nickname, name, gender, age, provider, profile_complete, created_at, updated_at, is_deleted)
+        VALUES (#{loginId}, #{email}, #{password}, #{nickname}, #{name}, #{gender}, #{age}, #{provider}, #{profileComplete}, #{createdAt}, #{updatedAt}, false)
     </insert>
 
     <select id="findById" resultType="com.example.playlist.member.entity.Member">
-        SELECT * FROM member WHERE id = #{id}
+        SELECT * FROM member WHERE id = #{memberId}
     </select>
 
     <select id="findByEmail" resultType="com.example.playlist.member.entity.Member">
@@ -20,4 +20,14 @@
     <select id="findByLoginId" resultType="com.example.playlist.member.entity.Member">
         SELECT * FROM member WHERE login_id = #{loginId}
     </select>
+
+    <update id="updateProfile">
+        UPDATE member
+        SET nickname = #{nickname},
+            age      = #{age},
+            gender   = #{gender},
+            profile_complete = true,
+            updated_at = NOW()
+        WHERE id = #{memberId}
+    </update>
 </mapper>

--- a/src/main/resources/mapper/MemberSocialMapper.xml
+++ b/src/main/resources/mapper/MemberSocialMapper.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.example.playlist.member.repository.MemberSocialMapper">
+
+    <insert id="save" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO member_social (member_id, provider, provider_id, created_at)
+        VALUES (#{memberId}, #{provider}, #{providerId}, #{createdAt})
+    </insert>
+
+    <select id="findByProviderAndProviderId" resultType="com.example.playlist.member.entity.MemberSocial">
+        SELECT *
+        FROM member_social
+        WHERE provider = #{provider}
+          AND provider_id = #{providerId}
+    </select>
+
+</mapper>

--- a/src/main/resources/mapper/PlaylistMapper.xml
+++ b/src/main/resources/mapper/PlaylistMapper.xml
@@ -20,13 +20,13 @@
         VALUES (#{playlistId}, #{songId}, #{position})
     </insert>
 
-    <select id="findSongBySpotifyTrackId" resultType="com.example.playlist.Entity.Song">
+    <select id="findSongBySpotifyTrackId" resultType="com.example.playlist.playlist.entity.Song">
         SELECT id, spotify_track_id, spotify_track_uri, title, artist, album
         FROM song
         WHERE spotify_track_id = #{spotifyTrackId}
     </select>
 
-    <select id="findByMemberId" resultType="com.example.playlist.Entity.Playlist">
+    <select id="findByMemberId" resultType="com.example.playlist.playlist.entity.Playlist">
         SELECT id, member_id, spotify_playlist_id, name, prompt, created_at
         FROM playlist
         WHERE member_id = #{memberId}

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,18 +1,36 @@
 CREATE TABLE IF NOT EXISTS member
 (
-    id         BIGSERIAL PRIMARY KEY,
-    login_id   VARCHAR(50)  UNIQUE NOT NULL,
-    email      VARCHAR(255) UNIQUE NOT NULL,
-    password   VARCHAR(255) NOT NULL,
-    nickname   VARCHAR(50)  NOT NULL,
-    name       VARCHAR(50)  NOT NULL,
-    gender     VARCHAR(10),
-    age        INTEGER,
-    provider   VARCHAR(20)  DEFAULT 'LOCAL',
-    created_at TIMESTAMP    DEFAULT NOW(),
-    updated_at TIMESTAMP    DEFAULT NOW(),
-    is_deleted BOOLEAN      DEFAULT false
+    id               BIGSERIAL PRIMARY KEY,
+    login_id         VARCHAR(50)  UNIQUE NOT NULL,
+    email            VARCHAR(255) UNIQUE NOT NULL,
+    password         VARCHAR(255),
+    nickname         VARCHAR(50),
+    name             VARCHAR(50)  NOT NULL,
+    gender           VARCHAR(10),
+    age              INTEGER,
+    provider         VARCHAR(20)  DEFAULT 'LOCAL',
+    profile_complete BOOLEAN      DEFAULT true,
+    created_at       TIMESTAMP    DEFAULT NOW(),
+    updated_at       TIMESTAMP    DEFAULT NOW(),
+    is_deleted       BOOLEAN      DEFAULT false
 );
+
+-- 소셜 계정 연동 테이블 (한 회원이 여러 소셜 계정을 가질 수 있음)
+CREATE TABLE IF NOT EXISTS member_social
+(
+    id          BIGSERIAL PRIMARY KEY,
+    member_id   BIGINT       NOT NULL REFERENCES member (id) ON DELETE CASCADE,
+    provider    VARCHAR(20)  NOT NULL,
+    provider_id VARCHAR(255) NOT NULL,
+    created_at  TIMESTAMP    DEFAULT NOW(),
+    UNIQUE (provider, provider_id)
+);
+
+-- 기존 DB에 컬럼이 없는 경우를 위한 마이그레이션 (이미 테이블이 존재할 때)
+-- 아래 DDL은 최초 실행 시 오류가 날 수 있으므로, 기존 DB라면 직접 실행하세요
+-- ALTER TABLE member ADD COLUMN IF NOT EXISTS profile_complete BOOLEAN DEFAULT true;
+-- ALTER TABLE member ALTER COLUMN password DROP NOT NULL;
+-- ALTER TABLE member ALTER COLUMN nickname DROP NOT NULL;
 
 CREATE TABLE IF NOT EXISTS playlist
 (


### PR DESCRIPTION
## 📌 개요

Google, Spotify 소셜 로그인을 구현하고, 동일 이메일 계정 통합 및 소셜 신규 회원의 추가정보 입력 흐름을 구축했습니다.

---

## 🗂️ 주요 변경사항

### 1. DB 스키마 변경 (`schema.sql`)

**`member` 테이블 변경**
- `password` → nullable (소셜 전용 회원은 비밀번호 없음)
- `nickname` → nullable (소셜 신규 회원은 추가정보 입력 전 없음)
- `profile_complete BOOLEAN DEFAULT true` 컬럼 추가
  - LOCAL 가입: 기본값 `true`
  - 소셜 신규 가입: `false` → 추가정보 입력 완료 후 `true`

**`member_social` 테이블 신규 추가**
```sql
CREATE TABLE member_social (
    id          BIGSERIAL PRIMARY KEY,
    member_id   BIGINT NOT NULL REFERENCES member(id) ON DELETE CASCADE,
    provider    VARCHAR(20) NOT NULL,   -- GOOGLE, SPOTIFY
    provider_id VARCHAR(255) NOT NULL,  -- 각 소셜 서비스의 고유 ID
    created_at  TIMESTAMP DEFAULT NOW(),
    UNIQUE(provider, provider_id)
);
```

> 한 회원이 여러 소셜 계정을 연결할 수 있도록 별도 테이블로 분리

---

### 2. 계정 통합 로직 (`CustomOAuth2UserService`)

소셜 로그인 시 아래 순서로 처리됩니다.

```
소셜 로그인 콜백 (email, providerId 수신)
        │
        ├─ 1. member_social에 (provider, providerId) 존재?
        │      YES → 기존 소셜 계정 → 로그인 완료
        │
        ├─ 2. member에 동일 email 존재?
        │      YES → 소셜 계정 연결 (계정 통합) → 로그인 완료
        │
        └─ 3. 둘 다 없음 → 신규 member 생성 + member_social 등록
                          + profileComplete = false
```

**예시 시나리오**
- `gmail@gmail.com`으로 일반 회원가입
- Google 소셜 로그인 시도 → 같은 email → `member_social`에 GOOGLE row 추가 (통합)
- Spotify 소셜 로그인 (Spotify 계정이 Google로 가입된 경우)
  → Spotify도 `gmail@gmail.com` 반환 → 자동으로 기존 계정에 통합

---

### 3. STATELESS + OAuth2 세션 문제 해결 (`HttpCookieOAuth2AuthorizationRequestRepository`)

**문제 원인**

Spring Security OAuth2는 기본적으로 로그인 시작 시 인증 요청 정보를 **HTTP 세션**에 저장합니다.  
그런데 현재 설정이 `SessionCreationPolicy.STATELESS`이기 때문에 세션이 유지되지 않아,  
소셜 서버 콜백 시 저장해둔 인증 요청을 찾지 못하는 문제가 발생했습니다.

```
[OAuth2] 로그인 실패: [authorization_request_not_found]
```

**해결 방법**

세션 대신 **쿠키**에 인증 요청 정보를 저장하는 `HttpCookieOAuth2AuthorizationRequestRepository` 구현

```
로그인 시작 → OAuth2AuthorizationRequest 직렬화 → 쿠키(oauth2_auth_request)에 저장 (3분 만료)
콜백 도착  → 쿠키에서 역직렬화 → 인증 요청 복원 → state 검증 → 로그인 처리
완료       → 쿠키 삭제
```

**보안 고려사항**
- 쿠키에 저장되는 정보: `state` 값, `redirect_uri`, `scope` (민감정보 없음)
- `HttpOnly=true` → JS에서 접근 불가 (XSS 방어)
- 3분 만료 → 탈취해도 사용 시간 극히 짧음
- `state` 검증 → CSRF 방어

---

### 4. localhost vs 127.0.0.1 쿠키 도메인 문제

**문제 원인**

Spotify는 Developer Dashboard에서 `localhost` redirect URI를 지원하지 않아 `127.0.0.1`을 사용해야 합니다.  
이 때문에 OAuth 시작 URL과 콜백 URL의 호스트가 다를 경우 세션/쿠키 불일치 문제가 발생했습니다.

```
OAuth 시작: localhost:8080 → 세션/쿠키 = localhost 기준 발급
OAuth 콜백: 127.0.0.1:8080 → localhost 쿠키 미전송 → authorization_request_not_found
```

**해결**
- Vite 프록시 포트 수정 (`http://127.0.0.1` → `http://127.0.0.1:8080`)
- Google/Spotify redirect-uri 모두 `127.0.0.1`로 통일
- 프론트엔드 OAuth 버튼 URL도 `127.0.0.1`로 통일

---

### 5. 로그아웃 시 쿠키 미삭제 버그 수정 (`JwtUtil`)

**문제**  
로그아웃 시 Redis 블랙리스트 등록만 하고 **브라우저 쿠키를 삭제하지 않아**,  
로그아웃 후에도 accessToken 쿠키가 남아있었습니다.

**해결**  
`logout()` 메서드에 `HttpServletResponse` 추가, 로그아웃 시 accessToken/refreshToken 쿠키 즉시 삭제

```java
private void clearCookie(HttpServletResponse response, String cookieName) {
    Cookie cookie = new Cookie(cookieName, null);
    cookie.setMaxAge(0);  // 즉시 만료
    response.addCookie(cookie);
}
```

---

### 6. 소셜 신규 회원 추가정보 입력 흐름

소셜 로그인으로 처음 가입한 회원은 `nickname`, `age`, `gender` 정보가 없으므로 별도 입력 과정이 필요합니다.

```
소셜 신규 가입 (profileComplete=false)
        ↓
임시 토큰(tempToken, 10분) 발급
        ↓
프론트 /profile/complete 페이지로 리다이렉트
        ↓
POST /members/profile/complete { nickname, age, gender }
        ↓
DB 업데이트 + profileComplete=true
        ↓
정식 accessToken/refreshToken 발급
```

---

### 7. GET /members/me 엔드포인트 추가

프론트엔드 인증 상태 확인용 API. 소셜 로그인 후 리다이렉트 시 사용자 정보를 함께 받아올 수 있습니다.

```
GET /api/v1/members/me
Authorization: accessToken 쿠키

Response: { id, loginId, email, name, nickname, gender, age, provider, profileComplete }
```

---

## 🔧 프론트엔드 연동 가이드

### 소셜 로그인 버튼
```js
// Google
window.location.href = "http://127.0.0.1:8080/api/v1/oauth2/authorization/google"
// Spotify
window.location.href = "http://127.0.0.1:8080/api/v1/oauth2/authorization/spotify"
```

### 인증 상태 확인
```js
const checkAuth = async () => {
  const res = await fetch('/api/v1/members/me', { credentials: 'include' });
  if (res.status === 401) return null;
  return (await res.json()).result;
};
```

### 추가정보 입력
```js
// tempToken 쿠키 자동 포함됨
await fetch('/api/v1/members/profile/complete', {
  method: 'POST',
  credentials: 'include',
  headers: { 'Content-Type': 'application/json' },
  body: JSON.stringify({ nickname, gender, age })
});
```

---

## ⚙️ 환경변수 추가 필요 (`.env`)

```env
GOOGLE_CLIENT_ID=...
GOOGLE_CLIENT_SECRET=...
FRONTEND_URL=http://127.0.0.1:5173
```

## 🔗 외부 설정 필요

| 서비스 | 등록할 Redirect URI |
|---|---|
| Google Cloud Console | `http://127.0.0.1:8080/api/v1/login/oauth2/code/google` |
| Spotify Developer Dashboard | `http://127.0.0.1:8080/api/v1/login/oauth2/code/spotify` |

## 📋 기존 DB가 있는 경우 마이그레이션

```sql
ALTER TABLE member ADD COLUMN IF NOT EXISTS profile_complete BOOLEAN DEFAULT true;
ALTER TABLE member ALTER COLUMN password DROP NOT NULL;
ALTER TABLE member ALTER COLUMN nickname DROP NOT NULL;

CREATE TABLE IF NOT EXISTS member_social (
    id BIGSERIAL PRIMARY KEY,
    member_id BIGINT NOT NULL REFERENCES member(id) ON DELETE CASCADE,
    provider VARCHAR(20) NOT NULL,
    provider_id VARCHAR(255) NOT NULL,
    created_at TIMESTAMP DEFAULT NOW(),
    UNIQUE(provider, provider_id)
);
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)