### PR TITLE
feat: Spotify 플레이리스트 저장 기능 구현

### DIFF
--- a/src/main/java/com/example/playlist/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/playlist/global/config/SecurityConfig.java
@@ -6,13 +6,17 @@ import com.example.playlist.global.util.JwtUtil;
 import com.example.playlist.member.oauth2.CustomOAuth2UserService;
 import com.example.playlist.member.oauth2.OAuth2FailureHandler;
 import com.example.playlist.member.oauth2.OAuth2SuccessHandler;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -20,6 +24,7 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.List;
+import java.util.Map;
 
 @Configuration
 @EnableWebSecurity
@@ -35,6 +40,19 @@ public class SecurityConfig {
     @Bean
     public BCryptPasswordEncoder bCryptPasswordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationEntryPoint jsonAuthenticationEntryPoint() {
+        return (request, response, authException) -> {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setCharacterEncoding("UTF-8");
+            String body = new ObjectMapper().writeValueAsString(
+                    Map.of("status", 401, "message", "인증이 필요합니다.")
+            );
+            response.getWriter().write(body);
+        };
     }
 
     @Bean
@@ -54,6 +72,9 @@ public class SecurityConfig {
                         .requestMatchers("/oauth2/**", "/login/oauth2/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .anyRequest().authenticated()
+                )
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(jsonAuthenticationEntryPoint())
                 );
         http
                 .sessionManagement(session -> session

--- a/src/main/java/com/example/playlist/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/playlist/global/handler/GlobalExceptionHandler.java
@@ -3,11 +3,14 @@ package com.example.playlist.global.handler;
 import com.example.playlist.global.error.BaseException;
 import com.example.playlist.global.error.ErrorCode;
 import com.example.playlist.global.error.ErrorResponse;
+import com.example.playlist.playlist.exception.PlaylistErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 @Slf4j
 @RestControllerAdvice
@@ -15,6 +18,33 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(BaseException.class)
     public ResponseEntity<ErrorResponse> handleBaseException(BaseException e, HttpServletRequest request) {
         return getErrorResponse(e, e.getErrorCode(), request);
+    }
+
+    /**
+     * Spotify API 호출 실패 처리
+     * - 401: 토큰 만료 → 재로그인 안내
+     * - 403: 권한 부족 → 재로그인(스코프 재동의) 안내
+     * - 그 외: 일반 오류
+     */
+    @ExceptionHandler(WebClientResponseException.class)
+    public ResponseEntity<ErrorResponse> handleWebClientResponseException(
+            WebClientResponseException e, HttpServletRequest request) {
+        log.error("[WebClientResponseException] status={}, Request: {} {}\nSpotify 응답 본문: {}",
+                e.getStatusCode(), request.getMethod(), request.getRequestURI(),
+                e.getResponseBodyAsString());
+
+        PlaylistErrorCode errorCode;
+        if (e.getStatusCode() == HttpStatus.UNAUTHORIZED) {
+            errorCode = PlaylistErrorCode.SPOTIFY_TOKEN_EXPIRED;
+        } else if (e.getStatusCode() == HttpStatus.FORBIDDEN) {
+            errorCode = PlaylistErrorCode.SPOTIFY_FORBIDDEN;
+        } else {
+            errorCode = PlaylistErrorCode.SPOTIFY_API_ERROR;
+        }
+
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ErrorResponse.of(errorCode));
     }
 
     @ExceptionHandler(RuntimeException.class)

--- a/src/main/java/com/example/playlist/member/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/playlist/member/oauth2/CustomOAuth2UserService.java
@@ -7,12 +7,15 @@ import com.example.playlist.member.repository.MemberMapper;
 import com.example.playlist.member.repository.MemberSocialMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
 
@@ -33,6 +36,9 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     private final MemberMapper memberMapper;
     private final MemberSocialMapper memberSocialMapper;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public static final String SPOTIFY_USER_TOKEN_KEY = "SPOTIFY_USER_TOKEN:";
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
@@ -44,6 +50,21 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         OAuthAttributes oAuthAttributes = OAuthAttributes.of(registrationId, attributes);
 
         Member member = processOAuth2User(oAuthAttributes);
+
+        // Spotify 로그인 시 유저 액세스 토큰을 Redis에 저장
+        if ("spotify".equalsIgnoreCase(registrationId)) {
+            String spotifyAccessToken = userRequest.getAccessToken().getTokenValue();
+            Instant expiresAt = userRequest.getAccessToken().getExpiresAt();
+            long ttlSeconds = expiresAt != null
+                    ? Duration.between(Instant.now(), expiresAt).getSeconds()
+                    : 3600L;
+            redisTemplate.opsForValue().set(
+                    SPOTIFY_USER_TOKEN_KEY + member.getId(),
+                    spotifyAccessToken,
+                    Duration.ofSeconds(Math.max(ttlSeconds, 60))
+            );
+            log.info("[OAuth2] Spotify 유저 토큰 저장 - memberId={}", member.getId());
+        }
 
         return new CustomOAuth2User(
                 attributes,

--- a/src/main/java/com/example/playlist/member/repository/MemberSocialMapper.java
+++ b/src/main/java/com/example/playlist/member/repository/MemberSocialMapper.java
@@ -11,5 +11,9 @@ public interface MemberSocialMapper {
 
     Optional<MemberSocial> findByProviderAndProviderId(@Param("provider") String provider,
                                                        @Param("providerId") String providerId);
+
+    Optional<MemberSocial> findByMemberIdAndProvider(@Param("memberId") Long memberId,
+                                                      @Param("provider") String provider);
+
     void save(MemberSocial memberSocial);
 }

--- a/src/main/java/com/example/playlist/playlist/controller/PlaylistController.java
+++ b/src/main/java/com/example/playlist/playlist/controller/PlaylistController.java
@@ -1,15 +1,22 @@
 package com.example.playlist.playlist.controller;
 
 import com.example.playlist.gemini.dto.GeminiRequest;
+import com.example.playlist.global.success.SuccessResponse;
 import com.example.playlist.playlist.dto.PlaylistResponse;
+import com.example.playlist.playlist.exception.PlaylistSuccessCode;
+import com.example.playlist.playlist.dto.SaveNewPlaylistRequest;
+import com.example.playlist.playlist.dto.SaveToExistingPlaylistRequest;
 import com.example.playlist.playlist.service.PlaylistService;
+import com.example.playlist.spotify.dto.SpotifyUserPlaylistsResponse;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,15 +25,42 @@ public class PlaylistController {
 
     private final PlaylistService playlistService;
 
-    @Operation(
-            summary = "실제 플레이리스트 반환",
-            description = "GEMINI가 추천해준 플레이리스트를 Spotify API를 활용해 검색해주는 컨트롤러"
-    )
+    @Operation(summary = "AI 플레이리스트 추천", description = "Gemini가 추천한 곡들을 Spotify에서 검색해서 반환 (DB 미저장)")
     @PostMapping
     public PlaylistResponse createPlaylist(
             @RequestBody GeminiRequest geminiRequest
-            ) throws JsonProcessingException {
+    ) throws JsonProcessingException {
         return playlistService.createPlayList(geminiRequest);
     }
 
+    @Operation(summary = "내 Spotify 플레이리스트 목록 조회", description = "기존 플레이리스트에 추가하기 전 목록 불러오기")
+    @GetMapping("/spotify/my-playlists")
+    public ResponseEntity<SuccessResponse<SpotifyUserPlaylistsResponse>> getMySpotifyPlaylists(
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        SpotifyUserPlaylistsResponse result = playlistService.getUserSpotifyPlaylists(userDetails.getUsername());
+        return ResponseEntity.ok(SuccessResponse.of(PlaylistSuccessCode.PLAYLIST_ADDED, result));
+    }
+
+    @Operation(summary = "새 Spotify 플레이리스트 생성 후 저장", description = "새 플레이리스트를 만들고 추천곡 추가 + DB 저장")
+    @PostMapping("/spotify/save-new")
+    public ResponseEntity<SuccessResponse> saveAsNewPlaylist(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody @Valid SaveNewPlaylistRequest request
+    ) throws InterruptedException {
+        playlistService.saveAsNewPlaylist(userDetails.getUsername(), request);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(SuccessResponse.of(PlaylistSuccessCode.PLAYLIST_SAVED));
+    }
+
+    @Operation(summary = "기존 Spotify 플레이리스트에 추가 + 저장", description = "선택한 기존 플레이리스트에 추천곡 추가 + DB 저장")
+    @PostMapping("/spotify/save-existing")
+    public ResponseEntity<SuccessResponse> saveToExistingPlaylist(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody @Valid SaveToExistingPlaylistRequest request
+    ) {
+        playlistService.saveToExistingPlaylist(userDetails.getUsername(), request);
+        return ResponseEntity.ok(SuccessResponse.of(PlaylistSuccessCode.PLAYLIST_ADDED));
+    }
 }

--- a/src/main/java/com/example/playlist/playlist/dto/SaveNewPlaylistRequest.java
+++ b/src/main/java/com/example/playlist/playlist/dto/SaveNewPlaylistRequest.java
@@ -1,0 +1,22 @@
+package com.example.playlist.playlist.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class SaveNewPlaylistRequest {
+
+    @NotBlank
+    private String playlistName;
+
+    @NotBlank
+    private String prompt;
+
+    @NotEmpty
+    private List<SpotifyTrackSaveRequest> tracks;
+}

--- a/src/main/java/com/example/playlist/playlist/dto/SaveToExistingPlaylistRequest.java
+++ b/src/main/java/com/example/playlist/playlist/dto/SaveToExistingPlaylistRequest.java
@@ -1,0 +1,26 @@
+package com.example.playlist.playlist.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class SaveToExistingPlaylistRequest {
+
+    /** Spotify 플레이리스트 ID (사용자가 선택한 기존 플레이리스트) */
+    @NotBlank
+    private String targetSpotifyPlaylistId;
+
+    @NotBlank
+    private String playlistName;
+
+    @NotBlank
+    private String prompt;
+
+    @NotEmpty
+    private List<SpotifyTrackSaveRequest> tracks;
+}

--- a/src/main/java/com/example/playlist/playlist/dto/SpotifyTrackSaveRequest.java
+++ b/src/main/java/com/example/playlist/playlist/dto/SpotifyTrackSaveRequest.java
@@ -1,0 +1,14 @@
+package com.example.playlist.playlist.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SpotifyTrackSaveRequest {
+    private String spotifyTrackId;
+    private String spotifyTrackUri;
+    private String title;
+    private String artist;
+    private String album;
+}

--- a/src/main/java/com/example/playlist/playlist/exception/PlaylistErrorCode.java
+++ b/src/main/java/com/example/playlist/playlist/exception/PlaylistErrorCode.java
@@ -1,0 +1,23 @@
+package com.example.playlist.playlist.exception;
+
+import com.example.playlist.global.error.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum PlaylistErrorCode implements ErrorCode {
+
+    SPOTIFY_NOT_CONNECTED(HttpStatus.BAD_REQUEST,
+            "Spotify 연동이 필요합니다. Spotify 소셜 로그인을 먼저 진행해주세요."),
+    SPOTIFY_TOKEN_EXPIRED(HttpStatus.BAD_REQUEST,
+            "Spotify 토큰이 만료되었거나 권한이 부족합니다. Spotify 소셜 로그인을 다시 진행해주세요."),
+    SPOTIFY_FORBIDDEN(HttpStatus.FORBIDDEN,
+            "Spotify 플레이리스트 수정 권한이 없습니다. 본인이 소유한 플레이리스트만 수정할 수 있습니다."),
+    SPOTIFY_API_ERROR(HttpStatus.BAD_GATEWAY,
+            "Spotify API 호출 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/example/playlist/playlist/exception/PlaylistException.java
+++ b/src/main/java/com/example/playlist/playlist/exception/PlaylistException.java
@@ -1,0 +1,10 @@
+package com.example.playlist.playlist.exception;
+
+import com.example.playlist.global.error.BaseException;
+
+public class PlaylistException extends BaseException {
+
+    public PlaylistException(PlaylistErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/playlist/playlist/exception/PlaylistSuccessCode.java
+++ b/src/main/java/com/example/playlist/playlist/exception/PlaylistSuccessCode.java
@@ -1,0 +1,20 @@
+package com.example.playlist.playlist.exception;
+
+import com.example.playlist.global.success.SuccessCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum PlaylistSuccessCode implements SuccessCode {
+
+    PLAYLIST_SAVED(HttpStatus.CREATED, "플레이리스트가 저장되었습니다."),
+    PLAYLIST_ADDED(HttpStatus.OK, "기존 플레이리스트에 트랙이 추가되었습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    PlaylistSuccessCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/example/playlist/playlist/repository/PlaylistMapper.java
+++ b/src/main/java/com/example/playlist/playlist/repository/PlaylistMapper.java
@@ -1,0 +1,24 @@
+package com.example.playlist.playlist.repository;
+
+import com.example.playlist.playlist.entity.Playlist;
+import com.example.playlist.playlist.entity.PlaylistSong;
+import com.example.playlist.playlist.entity.Song;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+@Mapper
+public interface PlaylistMapper {
+
+    void insertPlaylist(Playlist playlist);
+
+    void insertSong(Song song);
+
+    void insertPlaylistSong(PlaylistSong playlistSong);
+
+    Optional<Song> findSongBySpotifyTrackId(@Param("spotifyTrackId") String spotifyTrackId);
+
+    List<Playlist> findByMemberId(@Param("memberId") Long memberId);
+}

--- a/src/main/java/com/example/playlist/playlist/service/PlaylistService.java
+++ b/src/main/java/com/example/playlist/playlist/service/PlaylistService.java
@@ -3,24 +3,44 @@ package com.example.playlist.playlist.service;
 import com.example.playlist.gemini.dto.GeminiRequest;
 import com.example.playlist.gemini.dto.GeminiResponse;
 import com.example.playlist.gemini.service.GeminiService;
+import com.example.playlist.member.repository.MemberMapper;
+import com.example.playlist.member.repository.MemberSocialMapper;
+import com.example.playlist.member.oauth2.CustomOAuth2UserService;
+import com.example.playlist.playlist.repository.PlaylistMapper;
+import com.example.playlist.playlist.exception.PlaylistErrorCode;
+import com.example.playlist.playlist.exception.PlaylistException;
 import com.example.playlist.playlist.dto.PlaylistResponse;
+import com.example.playlist.playlist.dto.SaveNewPlaylistRequest;
+import com.example.playlist.playlist.dto.SaveToExistingPlaylistRequest;
+import com.example.playlist.playlist.dto.SpotifyTrackSaveRequest;
+import com.example.playlist.playlist.entity.Playlist;
+import com.example.playlist.playlist.entity.PlaylistSong;
+import com.example.playlist.playlist.entity.Song;
 import com.example.playlist.spotify.dto.SpotifyTrack;
+import com.example.playlist.spotify.dto.SpotifyUserPlaylistsResponse;
 import com.example.playlist.spotify.service.SpotifyService;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 import reactor.core.publisher.Flux;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PlaylistService {
 
     private final GeminiService geminiService;
     private final SpotifyService spotifyService;
+    private final PlaylistMapper playlistMapper;
+    private final MemberMapper memberMapper;
+    private final MemberSocialMapper memberSocialMapper;
+    private final RedisTemplate<String, String> redisTemplate;
 
-    public PlaylistResponse createPlayList(GeminiRequest request) throws JsonProcessingException {
+    /** AI 추천 플레이리스트 생성 (DB 미저장, 결과만 반환) */
+    public PlaylistResponse createPlayList(GeminiRequest request) throws com.fasterxml.jackson.core.JsonProcessingException {
         GeminiResponse geminiResponse = geminiService.CreatePlaylist(request);
 
         List<SpotifyTrack> tracks = Flux.fromIterable(geminiResponse.getSongs())
@@ -29,5 +49,96 @@ public class PlaylistService {
                 .block();
 
         return new PlaylistResponse(geminiResponse.getPlaylistTitle(), tracks);
+    }
+
+    /** 유저의 Spotify 플레이리스트 목록 반환 */
+    public SpotifyUserPlaylistsResponse getUserSpotifyPlaylists(String loginId) {
+        String userToken = getSpotifyUserToken(loginId);
+        return spotifyService.getUserPlaylists(userToken);
+    }
+
+    /** 새 Spotify 플레이리스트 생성 후 트랙 추가 + DB 저장 */
+    public void saveAsNewPlaylist(String loginId, SaveNewPlaylistRequest req) {
+        Long memberId = getMemberId(loginId);
+        String userToken = getSpotifyUserToken(loginId);
+
+        String spotifyPlaylistId = spotifyService.createPlaylist(req.getPlaylistName(), userToken);
+        log.info("[Playlist] 새 플레이리스트 생성됨 - spotifyPlaylistId={}", spotifyPlaylistId);
+
+        List<String> trackUris = req.getTracks().stream()
+                .map(SpotifyTrackSaveRequest::getSpotifyTrackUri)
+                .toList();
+        spotifyService.addTracksToPlaylist(spotifyPlaylistId, trackUris, userToken);
+
+        savePlaylistToDB(memberId, spotifyPlaylistId, req.getPlaylistName(), req.getPrompt(), req.getTracks());
+        log.info("[Playlist] 새 플레이리스트 생성 완료 - memberId={}, spotifyPlaylistId={}", memberId, spotifyPlaylistId);
+    }
+
+    /** 기존 Spotify 플레이리스트에 트랙 추가 + DB 저장 */
+    public void saveToExistingPlaylist(String loginId, SaveToExistingPlaylistRequest req) {
+        Long memberId = getMemberId(loginId);
+        String userToken = getSpotifyUserToken(loginId);
+
+        List<String> trackUris = req.getTracks().stream()
+                .map(SpotifyTrackSaveRequest::getSpotifyTrackUri)
+                .toList();
+        spotifyService.addTracksToPlaylist(req.getTargetSpotifyPlaylistId(), trackUris, userToken);
+
+        savePlaylistToDB(memberId, req.getTargetSpotifyPlaylistId(), req.getPlaylistName(), req.getPrompt(), req.getTracks());
+        log.info("[Playlist] 기존 플레이리스트에 추가 완료 - memberId={}, spotifyPlaylistId={}", memberId, req.getTargetSpotifyPlaylistId());
+    }
+
+    // ─────────────────────────────────────────────
+    // 내부 헬퍼
+    // ─────────────────────────────────────────────
+
+    private void savePlaylistToDB(Long memberId, String spotifyPlaylistId, String name, String prompt,
+                                  List<SpotifyTrackSaveRequest> tracks) {
+        Playlist playlist = Playlist.builder()
+                .memberId(memberId)
+                .spotifyPlaylistId(spotifyPlaylistId)
+                .name(name)
+                .prompt(prompt)
+                .build();
+        playlistMapper.insertPlaylist(playlist);
+
+        for (int i = 0; i < tracks.size(); i++) {
+            SpotifyTrackSaveRequest t = tracks.get(i);
+
+            Song song = playlistMapper.findSongBySpotifyTrackId(t.getSpotifyTrackId())
+                    .orElseGet(() -> {
+                        Song newSong = Song.builder()
+                                .spotifyTrackId(t.getSpotifyTrackId())
+                                .spotifyTrackUri(t.getSpotifyTrackUri())
+                                .title(t.getTitle())
+                                .artist(t.getArtist())
+                                .album(t.getAlbum())
+                                .build();
+                        playlistMapper.insertSong(newSong);
+                        return newSong;
+                    });
+
+            PlaylistSong ps = PlaylistSong.builder()
+                    .playlistId(playlist.getId())
+                    .songId(song.getId())
+                    .position(i + 1)
+                    .build();
+            playlistMapper.insertPlaylistSong(ps);
+        }
+    }
+
+    private Long getMemberId(String loginId) {
+        return memberMapper.findByLoginId(loginId)
+                .orElseThrow(() -> new IllegalStateException("회원 정보를 찾을 수 없습니다."))
+                .getId();
+    }
+
+    private String getSpotifyUserToken(String loginId) {
+        Long memberId = getMemberId(loginId);
+        String token = redisTemplate.opsForValue().get(CustomOAuth2UserService.SPOTIFY_USER_TOKEN_KEY + memberId);
+        if (token == null) {
+            throw new PlaylistException(PlaylistErrorCode.SPOTIFY_NOT_CONNECTED);
+        }
+        return token;
     }
 }

--- a/src/main/java/com/example/playlist/spotify/dto/SpotifyCreatePlaylistResponse.java
+++ b/src/main/java/com/example/playlist/spotify/dto/SpotifyCreatePlaylistResponse.java
@@ -1,0 +1,9 @@
+package com.example.playlist.spotify.dto;
+
+import lombok.Getter;
+
+@Getter
+public class SpotifyCreatePlaylistResponse {
+    private String id;
+    private String name;
+}

--- a/src/main/java/com/example/playlist/spotify/dto/SpotifyCurrentUserResponse.java
+++ b/src/main/java/com/example/playlist/spotify/dto/SpotifyCurrentUserResponse.java
@@ -1,0 +1,15 @@
+package com.example.playlist.spotify.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class SpotifyCurrentUserResponse {
+
+    private String id;
+
+    @JsonProperty("display_name")
+    private String displayName;
+
+    private String email;
+}

--- a/src/main/java/com/example/playlist/spotify/dto/SpotifyUserPlaylistsResponse.java
+++ b/src/main/java/com/example/playlist/spotify/dto/SpotifyUserPlaylistsResponse.java
@@ -1,0 +1,41 @@
+package com.example.playlist.spotify.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class SpotifyUserPlaylistsResponse {
+
+    private List<PlaylistItem> items;
+
+    @Getter
+    public static class PlaylistItem {
+        private String id;
+        private String name;
+        private List<Image> images;
+        private Owner owner;
+
+        @JsonProperty("tracks")
+        private TracksInfo tracks;
+    }
+
+    @Getter
+    public static class Owner {
+        private String id;
+
+        @JsonProperty("display_name")
+        private String displayName;
+    }
+
+    @Getter
+    public static class Image {
+        private String url;
+    }
+
+    @Getter
+    public static class TracksInfo {
+        private int total;
+    }
+}

--- a/src/main/java/com/example/playlist/spotify/service/SpotifyService.java
+++ b/src/main/java/com/example/playlist/spotify/service/SpotifyService.java
@@ -1,18 +1,31 @@
 package com.example.playlist.spotify.service;
 
+import com.example.playlist.spotify.dto.SpotifyCreatePlaylistResponse;
+import com.example.playlist.spotify.dto.SpotifyCurrentUserResponse;
 import com.example.playlist.spotify.dto.SpotifySearchResponse;
 import com.example.playlist.spotify.dto.SpotifyTrack;
+import com.example.playlist.spotify.dto.SpotifyUserPlaylistsResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class SpotifyService {
 
     private final SpotifyTokenService spotifyTokenService;
     private final WebClient spotifyWebClient;
+
+    // ─────────────────────────────────────────────
+    // 클라이언트 자격증명 토큰 사용 (트랙 검색)
+    // ─────────────────────────────────────────────
 
     public Mono<SpotifyTrack> searchTrack(String artist, String title) {
         String accessToken = spotifyTokenService.getAccessToken();
@@ -24,5 +37,81 @@ public class SpotifyService {
                 .retrieve()
                 .bodyToMono(SpotifySearchResponse.class)
                 .map(response -> SpotifyTrack.from(response.getTracks().getItems().get(0), title, artist));
+    }
+
+    // ─────────────────────────────────────────────
+    // 유저 액세스 토큰 사용 (플레이리스트 관련)
+    // ─────────────────────────────────────────────
+
+    /** 현재 Spotify 유저 프로필 조회 */
+    public SpotifyCurrentUserResponse getCurrentUser(String userToken) {
+        return spotifyWebClient
+                .get()
+                .uri("/me")
+                .header("Authorization", "Bearer " + userToken)
+                .retrieve()
+                .bodyToMono(SpotifyCurrentUserResponse.class)
+                .block();
+    }
+
+    /** 유저가 소유한 Spotify 플레이리스트 목록 조회 (팔로우 플레이리스트 제외) */
+    public SpotifyUserPlaylistsResponse getUserPlaylists(String userToken) {
+        String mySpotifyId = getCurrentUser(userToken).getId();
+
+        SpotifyUserPlaylistsResponse all = spotifyWebClient
+                .get()
+                .uri("/me/playlists?limit=50")
+                .header("Authorization", "Bearer " + userToken)
+                .retrieve()
+                .bodyToMono(SpotifyUserPlaylistsResponse.class)
+                .block();
+
+        if (all != null && all.getItems() != null) {
+            all.getItems().removeIf(item ->
+                    item.getOwner() == null || !mySpotifyId.equals(item.getOwner().getId())
+            );
+        }
+        return all;
+    }
+
+    /** 새 Spotify 플레이리스트 생성 후 ID 반환 */
+    public String createPlaylist(String name, String userToken) {
+        SpotifyCreatePlaylistResponse response = spotifyWebClient
+                .post()
+                .uri("/me/playlists")
+                .header("Authorization", "Bearer " + userToken)
+                .header("Content-Type", "application/json")
+                .bodyValue(Map.of(
+                        "name", name,
+                        "public", false,
+                        "description", "AI 추천 플레이리스트"
+                ))
+                .retrieve()
+                .bodyToMono(SpotifyCreatePlaylistResponse.class)
+                .block();
+
+        return response.getId();
+    }
+
+    /**
+     * Spotify 플레이리스트에 트랙 추가
+     * 2025년 2월부터 /tracks → /items 엔드포인트로 변경
+     */
+    public void addTracksToPlaylist(String playlistId, List<String> trackUris, String userToken) {
+        spotifyWebClient
+                .post()
+                .uri("/playlists/{playlistId}/items", playlistId)
+                .header("Authorization", "Bearer " + userToken)
+                .header("Content-Type", "application/json")
+                .bodyValue(Map.of("uris", trackUris))
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, response ->
+                        response.bodyToMono(String.class).flatMap(errorBody -> {
+                            log.error("[Spotify] 트랙 추가 실패 - status={}, body={}", response.statusCode(), errorBody);
+                            return Mono.error(new RuntimeException("Spotify 트랙 추가 실패: " + errorBody));
+                        })
+                )
+                .bodyToMono(Void.class)
+                .block();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -61,9 +61,12 @@ spring:
             scope:
               - user-read-email
               - user-read-private
+              - playlist-read-private
+              - playlist-modify-public
+              - playlist-modify-private
         provider:
           spotify:
-            authorization-uri: https://accounts.spotify.com/authorize
+            authorization-uri: https://accounts.spotify.com/authorize?show_dialog=true
             token-uri: https://accounts.spotify.com/api/token
             user-info-uri: https://api.spotify.com/v1/me
             user-name-attribute: id

--- a/src/main/resources/mapper/MemberSocialMapper.xml
+++ b/src/main/resources/mapper/MemberSocialMapper.xml
@@ -16,4 +16,11 @@
           AND provider_id = #{providerId}
     </select>
 
+    <select id="findByMemberIdAndProvider" resultType="com.example.playlist.member.entity.MemberSocial">
+        SELECT *
+        FROM member_social
+        WHERE member_id = #{memberId}
+          AND provider = #{provider}
+    </select>
+
 </mapper>

--- a/src/main/resources/mapper/PlaylistMapper.xml
+++ b/src/main/resources/mapper/PlaylistMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
-<mapper namespace="com.example.playlist.playlist.PlaylistMapper">
+<mapper namespace="com.example.playlist.playlist.repository.PlaylistMapper">
 
     <insert id="insertPlaylist" useGeneratedKeys="true" keyProperty="id">
         INSERT INTO playlist (member_id, spotify_playlist_id, name, prompt)


### PR DESCRIPTION
## 구현 내용

AI가 추천한 곡들을 Spotify 플레이리스트에 저장하는 기능을 구현했습니다.  
새 플레이리스트 생성 또는 기존 플레이리스트에 추가, 두 가지 방식을 모두 지원합니다.

---

## 에러 원인 및 해결 과정

### 1. 인증되지 않은 요청 시 HTML 반환 문제
- **원인**: Spring Security가 미인증 요청에 대해 기본적으로 HTML 로그인 페이지로 리다이렉트
- **해결**: `AuthenticationEntryPoint` 커스텀 구현 → 401 JSON 응답 반환

### 2. Spotify 소셜 로그인 403 (GET /me/playlists)
- **원인**: `application.yml` 스코프에 `playlist-read-private` 누락
- **해결**: Spotify OAuth 스코프에 `playlist-read-private`, `playlist-modify-public`, `playlist-modify-private` 추가

### 3. Jackson 역직렬화 실패 (Request DTO)
- **원인**: `SaveNewPlaylistRequest`, `SaveToExistingPlaylistRequest`, `SpotifyTrackSaveRequest`에 `@NoArgsConstructor` 누락
- **해결**: 모든 Request DTO에 `@NoArgsConstructor` 추가

### 4. POST /users/{userId}/playlists 403
- **원인**: Spotify 2024년 11월 정책 변경으로 타 유저 플레이리스트 생성 엔드포인트 제한
- **해결**: `/users/{id}/playlists` → `/me/playlists` 로 변경 (토큰 기반 자동 처리)

### 5. 기존 플레이리스트 선택 시 403 (소유권 문제)
- **원인**: `GET /me/playlists`는 팔로우한 타인 플레이리스트도 포함 반환 → 소유하지 않은 플레이리스트 수정 시도 시 403
- **해결**: `GET /me`로 현재 Spotify 유저 ID 조회 후, 본인 소유 플레이리스트만 필터링하여 반환

### 6. POST /playlists/{id}/tracks 403 (핵심 원인)
- **원인**: **Spotify가 2025년 2월부터 트랙 추가 엔드포인트를 `/tracks` → `/items`로 변경**, 구 엔드포인트는 403으로 차단
- **해결**: `POST /playlists/{id}/tracks` → `POST /playlists/{id}/items` 로 변경

---

## API별 흐름 및 동작 과정

### AI 추천 플레이리스트 생성
```
프론트 → POST /api/v1/playlist/create
  → GeminiService: 프롬프트로 곡 목록 생성
  → SpotifyService.searchTrack(): 각 곡을 Spotify에서 검색 (Client Credentials 토큰)
  → PlaylistResponse(제목 + 트랙 목록) 반환 (DB 미저장)
```

### Spotify 소셜 로그인 및 토큰 저장
```
프론트 → GET /oauth2/authorization/spotify
  → Spotify 동의 화면 (show_dialog=true로 항상 표시)
  → CustomOAuth2UserService.loadUser()
      → 회원 조회/생성/계정통합
      → Spotify AccessToken → Redis 저장 (키: SPOTIFY_USER_TOKEN:{memberId}, TTL: 1시간)
  → OAuth2SuccessHandler: JWT 발급 (AccessToken 쿠키 + RefreshToken Redis)
```

### 내 Spotify 플레이리스트 목록 조회
```
프론트 → GET /api/v1/playlist/spotify/my-playlists
  → PlaylistService.getUserSpotifyPlaylists()
      → Redis에서 Spotify 유저 토큰 조회
      → SpotifyService.getCurrentUser(): GET /me → 내 Spotify userId 조회
      → SpotifyService.getUserPlaylists(): GET /me/playlists
      → 본인 소유 플레이리스트만 필터링 (owner.id == mySpotifyId)
  → 필터링된 플레이리스트 목록 반환
```

### 새 플레이리스트 생성 후 저장
```
프론트 → POST /api/v1/playlist/spotify/save-new
  { playlistName, prompt, tracks: [{spotifyTrackId, spotifyTrackUri, title, artist, album}] }
  → PlaylistService.saveAsNewPlaylist()
      → SpotifyService.createPlaylist(): POST /me/playlists → spotifyPlaylistId 획득
      → SpotifyService.addTracksToPlaylist(): POST /playlists/{id}/items (2025.02 변경)
      → savePlaylistToDB():
          - playlist 테이블 INSERT
          - song 테이블 upsert (spotifyTrackId 기준 중복 체크)
          - playlist_song 테이블 INSERT (position 순서 유지)
```

### 기존 플레이리스트에 추가 후 저장
```
프론트 → POST /api/v1/playlist/spotify/save-existing
  { targetSpotifyPlaylistId, playlistName, prompt, tracks: [...] }
  → PlaylistService.saveToExistingPlaylist()
      → SpotifyService.addTracksToPlaylist(): POST /playlists/{id}/items
      → savePlaylistToDB(): 동일한 DB 저장 로직
```

---

## 주요 변경 파일

| 파일 | 변경 내용 |
|------|-----------|
| `SecurityConfig.java` | 미인증 시 JSON 401 응답 처리 |
| `CustomOAuth2UserService.java` | Spotify AccessToken Redis 저장 |
| `application.yml` | Spotify OAuth 스코프 추가, `show_dialog=true` |
| `SpotifyService.java` | `/me/playlists`, `/me`, `/playlists/{id}/items` 연동 |
| `PlaylistService.java` | 새 플레이리스트 생성 / 기존 플레이리스트 추가 / DB 저장 |
| `PlaylistMapper.java` | playlist, song, playlist_song INSERT / song upsert |
| `GlobalExceptionHandler.java` | WebClientResponseException 처리 (Spotify API 오류 분기) |
| `PlaylistErrorCode.java` | SPOTIFY_NOT_CONNECTED, SPOTIFY_FORBIDDEN, SPOTIFY_API_ERROR |
| Request DTOs | SaveNewPlaylistRequest, SaveToExistingPlaylistRequest, SpotifyTrackSaveRequest |
| Response DTOs | SpotifyUserPlaylistsResponse (owner 필터링), SpotifyCreatePlaylistResponse, SpotifyCurrentUserResponse |

🤖 Generated with [Claude Code](https://claude.com/claude-code)