### PR TITLE
feat: 마이페이지 조회 및 문의하기(Post) 기능 구현

### DIFF
--- a/src/main/java/com/example/playlist/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/playlist/global/config/SecurityConfig.java
@@ -32,6 +32,7 @@ import java.util.Map;
 public class SecurityConfig {
 
     private final JwtUtil jwtUtil;
+    private final JwtFilter jwtFilter;
     private final CustomOAuth2UserService customOAuth2UserService;
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
     private final OAuth2FailureHandler oAuth2FailureHandler;
@@ -71,6 +72,7 @@ public class SecurityConfig {
                         .requestMatchers("/members/profile/complete").permitAll()
                         .requestMatchers("/oauth2/**", "/login/oauth2/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling(ex -> ex
@@ -89,7 +91,7 @@ public class SecurityConfig {
                         .failureHandler(oAuth2FailureHandler)
                 );
         http
-                .addFilterBefore(new JwtFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/example/playlist/global/filter/JwtFilter.java
+++ b/src/main/java/com/example/playlist/global/filter/JwtFilter.java
@@ -1,6 +1,8 @@
 package com.example.playlist.global.filter;
 
 import com.example.playlist.global.util.JwtUtil;
+import com.example.playlist.member.entity.Member;
+import com.example.playlist.member.repository.MemberMapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -9,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -16,6 +19,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Optional;
 
 @Component
@@ -24,34 +28,39 @@ import java.util.Optional;
 public class JwtFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
+    private final MemberMapper memberMapper;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
         String accessToken = jwtUtil.extractAccessToken(request).orElse(null);
 
-        if( accessToken != null && jwtUtil.isTokenValid(accessToken)) {
+        if (accessToken != null && jwtUtil.isTokenValid(accessToken)) {
             Optional<String> loginIdOpt = jwtUtil.extractLoginId(accessToken);
+            String role = jwtUtil.extractRole(accessToken).orElse("USER");
 
-            if( loginIdOpt.isPresent()) {
-                saveAuthentication(loginIdOpt.get());
+            if (loginIdOpt.isPresent()) {
+                saveAuthentication(loginIdOpt.get(), role);
             }
-
             filterChain.doFilter(request, response);
             return;
         }
 
         String refreshToken = jwtUtil.extractRefreshToken(request).orElse(null);
 
-        if( refreshToken != null) {
+        if (refreshToken != null) {
             Optional<String> loginIdOpt = jwtUtil.extractLoginId(refreshToken);
 
-            if( loginIdOpt.isPresent() && jwtUtil.isRefreshTokenValid(refreshToken,  loginIdOpt.get())) {
-                String newAccessToken = jwtUtil.createAccessToken(loginIdOpt.get());
+            if (loginIdOpt.isPresent() && jwtUtil.isRefreshTokenValid(refreshToken, loginIdOpt.get())) {
+                Member member = memberMapper.findByLoginId(loginIdOpt.get()).orElse(null);
+                String role = member != null && member.getRole() != null ? member.getRole().name() : "USER";
+
+                String newAccessToken = jwtUtil.createAccessToken(loginIdOpt.get(), role);
                 String newRefreshToken = jwtUtil.createRefreshToken(loginIdOpt.get());
 
                 jwtUtil.updateRefreshToken(loginIdOpt.get(), newRefreshToken);
                 jwtUtil.sendAccessAndRefreshToken(response, newAccessToken, newRefreshToken);
+                saveAuthentication(loginIdOpt.get(), role);
 
                 log.info("AccessToken 재발급");
                 filterChain.doFilter(request, response);
@@ -61,15 +70,14 @@ public class JwtFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
-    public void saveAuthentication(String loginId) {
-
+    public void saveAuthentication(String loginId, String role) {
         UserDetails userDetails = User.builder()
                 .username(loginId)
                 .password("")
+                .authorities(List.of(new SimpleGrantedAuthority("ROLE_" + role)))
                 .build();
 
         Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
         SecurityContextHolder.getContext().setAuthentication(authentication);
     }
-
 }

--- a/src/main/java/com/example/playlist/global/util/JwtUtil.java
+++ b/src/main/java/com/example/playlist/global/util/JwtUtil.java
@@ -39,11 +39,12 @@ public class JwtUtil {
         return Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
     }
 
-    public String createAccessToken(String loginId) {
+    public String createAccessToken(String loginId, String role) {
         Date now = new Date();
         return Jwts.builder()
                 .subject("AccessToken")
                 .claim("loginId", loginId)
+                .claim("role", role)
                 .issuedAt(now)
                 .expiration(new Date(now.getTime() + accessTokenExpiration * 1000))
                 .signWith(getKey())
@@ -140,6 +141,16 @@ public class JwtUtil {
             );
         } catch (Exception e) {
             log.info("loginId 추출 실패: {}", e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    public Optional<String> extractRole(String token) {
+        try {
+            return Optional.ofNullable(
+                    parseClaims(token).get("role", String.class)
+            );
+        } catch (Exception e) {
             return Optional.empty();
         }
     }

--- a/src/main/java/com/example/playlist/member/controller/MemberController.java
+++ b/src/main/java/com/example/playlist/member/controller/MemberController.java
@@ -4,6 +4,7 @@ import com.example.playlist.global.success.SuccessResponse;
 import com.example.playlist.member.dto.JoinRequest;
 import com.example.playlist.member.dto.LoginRequest;
 import com.example.playlist.member.dto.MemberInfoResponse;
+import com.example.playlist.member.dto.MyPageResponse;
 import com.example.playlist.member.dto.SocialProfileCompleteRequest;
 import com.example.playlist.member.exception.MemberSuccessCode;
 import com.example.playlist.member.service.MemberService;
@@ -70,6 +71,14 @@ public class MemberController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(SuccessResponse.of(MemberSuccessCode.LOGOUT_SUCCESS));
+    }
+
+    @GetMapping("/mypage")
+    public ResponseEntity<SuccessResponse<MyPageResponse>> getMyPage(
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        MyPageResponse myPage = memberService.getMyPage(userDetails.getUsername());
+        return ResponseEntity.ok(SuccessResponse.of(MemberSuccessCode.MYPAGE_SUCCESS, myPage));
     }
 
     /**

--- a/src/main/java/com/example/playlist/member/dto/MyPageResponse.java
+++ b/src/main/java/com/example/playlist/member/dto/MyPageResponse.java
@@ -1,0 +1,28 @@
+package com.example.playlist.member.dto;
+
+import com.example.playlist.member.entity.Gender;
+import com.example.playlist.member.entity.Member;
+import com.example.playlist.playlist.entity.Playlist;
+import com.example.playlist.post.entity.Post;
+
+import java.util.List;
+
+public record MyPageResponse(
+        String name,
+        String email,
+        Integer age,
+        Gender gender,
+        List<PlaylistSummaryResponse> playlists,
+        List<PostSummaryResponse> posts
+) {
+    public static MyPageResponse of(Member member, List<Playlist> playlists, List<Post> posts) {
+        return new MyPageResponse(
+                member.getName(),
+                member.getEmail(),
+                member.getAge(),
+                member.getGender(),
+                playlists.stream().map(PlaylistSummaryResponse::from).toList(),
+                posts.stream().map(PostSummaryResponse::from).toList()
+        );
+    }
+}

--- a/src/main/java/com/example/playlist/member/dto/PlaylistSummaryResponse.java
+++ b/src/main/java/com/example/playlist/member/dto/PlaylistSummaryResponse.java
@@ -1,0 +1,21 @@
+package com.example.playlist.member.dto;
+
+import com.example.playlist.playlist.entity.Playlist;
+
+import java.time.LocalDateTime;
+
+public record PlaylistSummaryResponse(
+        Long id,
+        String name,
+        String prompt,
+        LocalDateTime createdAt
+) {
+    public static PlaylistSummaryResponse from(Playlist playlist) {
+        return new PlaylistSummaryResponse(
+                playlist.getId(),
+                playlist.getName(),
+                playlist.getPrompt(),
+                playlist.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/example/playlist/member/dto/PostSummaryResponse.java
+++ b/src/main/java/com/example/playlist/member/dto/PostSummaryResponse.java
@@ -1,0 +1,25 @@
+package com.example.playlist.member.dto;
+
+import com.example.playlist.post.entity.InquiryCategory;
+import com.example.playlist.post.entity.InquiryStatus;
+import com.example.playlist.post.entity.Post;
+
+import java.time.LocalDateTime;
+
+public record PostSummaryResponse(
+        Long id,
+        String title,
+        InquiryCategory category,
+        InquiryStatus status,
+        LocalDateTime createdAt
+) {
+    public static PostSummaryResponse from(Post post) {
+        return new PostSummaryResponse(
+                post.getId(),
+                post.getTitle(),
+                post.getCategory(),
+                post.getStatus(),
+                post.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/example/playlist/member/entity/Member.java
+++ b/src/main/java/com/example/playlist/member/entity/Member.java
@@ -18,6 +18,7 @@ public class Member {
     private Gender gender;
     private Integer age;
     private Provider provider;
+    private Role role;
     private boolean profileComplete;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
@@ -33,6 +34,7 @@ public class Member {
                 .gender(gender)
                 .age(age)
                 .provider(Provider.LOCAL)
+                .role(Role.USER)
                 .profileComplete(true)
                 .createdAt(LocalDateTime.now())
                 .updatedAt(LocalDateTime.now())
@@ -45,6 +47,7 @@ public class Member {
                 .email(email)
                 .name(name)
                 .provider(provider)
+                .role(Role.USER)
                 .profileComplete(false)
                 .createdAt(LocalDateTime.now())
                 .updatedAt(LocalDateTime.now())

--- a/src/main/java/com/example/playlist/member/entity/Role.java
+++ b/src/main/java/com/example/playlist/member/entity/Role.java
@@ -1,0 +1,5 @@
+package com.example.playlist.member.entity;
+
+public enum Role {
+    USER, ADMIN
+}

--- a/src/main/java/com/example/playlist/member/exception/MemberSuccessCode.java
+++ b/src/main/java/com/example/playlist/member/exception/MemberSuccessCode.java
@@ -10,7 +10,8 @@ public enum MemberSuccessCode implements SuccessCode {
     LOGIN_SUCCESS(HttpStatus.OK, "로그인이 성공적으로 완료되었습니다."),
     MEMBER_SUCCESS_SIGNUP(HttpStatus.OK, "회원가입이 성공적으로 완료되었습니다."),
     LOGOUT_SUCCESS(HttpStatus.OK, "로그아웃이 성공적으로 완료되었습니다."),
-    PROFILE_COMPLETE_SUCCESS(HttpStatus.OK, "추가 정보 입력이 완료되었습니다.");
+    PROFILE_COMPLETE_SUCCESS(HttpStatus.OK, "추가 정보 입력이 완료되었습니다."),
+    MYPAGE_SUCCESS(HttpStatus.OK, "마이페이지 조회 성공");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/example/playlist/member/oauth2/CustomOAuth2User.java
+++ b/src/main/java/com/example/playlist/member/oauth2/CustomOAuth2User.java
@@ -1,5 +1,6 @@
 package com.example.playlist.member.oauth2;
 
+import com.example.playlist.member.entity.Role;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -10,7 +11,7 @@ import java.util.Map;
 
 /**
  * OAuth2 로그인 후 SecurityContext에 담길 사용자 객체.
- * loginId, memberId, profileComplete 정보를 추가로 보유한다.
+ * loginId, memberId, profileComplete, role 정보를 추가로 보유한다.
  */
 @Getter
 public class CustomOAuth2User implements OAuth2User {
@@ -20,17 +21,20 @@ public class CustomOAuth2User implements OAuth2User {
     private final String loginId;
     private final Long memberId;
     private final boolean profileComplete;
+    private final Role role;
 
     public CustomOAuth2User(Map<String, Object> attributes,
                             String nameAttributeKey,
                             String loginId,
                             Long memberId,
-                            boolean profileComplete) {
+                            boolean profileComplete,
+                            Role role) {
         this.attributes = attributes;
         this.nameAttributeKey = nameAttributeKey;
         this.loginId = loginId;
         this.memberId = memberId;
         this.profileComplete = profileComplete;
+        this.role = role;
     }
 
     @Override

--- a/src/main/java/com/example/playlist/member/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/playlist/member/oauth2/CustomOAuth2UserService.java
@@ -71,7 +71,8 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                 oAuthAttributes.getNameAttributeKey(),
                 member.getLoginId(),
                 member.getId(),
-                member.isProfileComplete()
+                member.isProfileComplete(),
+                member.getRole()
         );
     }
 

--- a/src/main/java/com/example/playlist/member/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/example/playlist/member/oauth2/OAuth2SuccessHandler.java
@@ -44,7 +44,8 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         // 기존 회원 → 정상 토큰 발급
         String loginId = oauth2User.getLoginId();
-        String accessToken = jwtUtil.createAccessToken(loginId);
+        String role = oauth2User.getRole() != null ? oauth2User.getRole().name() : "USER";
+        String accessToken = jwtUtil.createAccessToken(loginId, role);
         String refreshToken = jwtUtil.createRefreshToken(loginId);
         jwtUtil.saveRefreshToken(loginId, refreshToken);
         jwtUtil.sendAccessAndRefreshToken(response, accessToken, refreshToken);

--- a/src/main/java/com/example/playlist/member/service/MemberService.java
+++ b/src/main/java/com/example/playlist/member/service/MemberService.java
@@ -2,14 +2,15 @@ package com.example.playlist.member.service;
 
 import com.example.playlist.global.util.JwtUtil;
 import com.example.playlist.global.util.RedisUtil;
-import com.example.playlist.member.dto.JoinRequest;
-import com.example.playlist.member.dto.JoinResponse;
-import com.example.playlist.member.dto.MemberInfoResponse;
-import com.example.playlist.member.dto.SocialProfileCompleteRequest;
+import com.example.playlist.member.dto.*;
 import com.example.playlist.member.entity.Member;
 import com.example.playlist.member.exception.MemberErrorCode;
 import com.example.playlist.member.exception.MemberException;
 import com.example.playlist.member.repository.MemberMapper;
+import com.example.playlist.playlist.entity.Playlist;
+import com.example.playlist.playlist.repository.PlaylistMapper;
+import com.example.playlist.post.entity.Post;
+import com.example.playlist.post.repository.PostMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +20,8 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class MemberService implements UserDetailsService {
@@ -27,6 +30,8 @@ public class MemberService implements UserDetailsService {
     private final MemberMapper memberMapper;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
     private final JwtUtil jwtUtil;
+    private final PlaylistMapper playlistMapper;
+    private final PostMapper postMapper;
 
     public JoinResponse join(JoinRequest request) {
         String verified = redisUtil.getData("verified:" + request.getEmail());
@@ -51,7 +56,6 @@ public class MemberService implements UserDetailsService {
         );
 
         memberMapper.save(member);
-
         return JoinResponse.of(member.getLoginId(), member.getNickname());
     }
 
@@ -63,7 +67,8 @@ public class MemberService implements UserDetailsService {
             throw new MemberException(MemberErrorCode.INVALID_PASSWORD);
         }
 
-        String accessToken = jwtUtil.createAccessToken(loginId);
+        String role = member.getRole() != null ? member.getRole().name() : "USER";
+        String accessToken = jwtUtil.createAccessToken(loginId, role);
         String refreshToken = jwtUtil.createRefreshToken(loginId);
 
         jwtUtil.saveRefreshToken(loginId, refreshToken);
@@ -80,10 +85,16 @@ public class MemberService implements UserDetailsService {
         return MemberInfoResponse.from(member);
     }
 
-    /**
-     * 소셜 신규 회원 추가정보 입력 완료.
-     * tempToken 쿠키를 검증 후 nickname/age/gender 저장 → 정식 토큰 발급.
-     */
+    public MyPageResponse getMyPage(String loginId) {
+        Member member = memberMapper.findByLoginId(loginId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        List<Playlist> playlists = playlistMapper.findByMemberId(member.getId());
+        List<Post> posts = postMapper.findByMemberId(member.getId());
+
+        return MyPageResponse.of(member, playlists, posts);
+    }
+
     public void completeProfile(HttpServletRequest request,
                                 HttpServletResponse response,
                                 SocialProfileCompleteRequest profileRequest) {
@@ -95,7 +106,8 @@ public class MemberService implements UserDetailsService {
         Member member = memberMapper.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
-        String accessToken = jwtUtil.createAccessToken(member.getLoginId());
+        String role = member.getRole() != null ? member.getRole().name() : "USER";
+        String accessToken = jwtUtil.createAccessToken(member.getLoginId(), role);
         String refreshToken = jwtUtil.createRefreshToken(member.getLoginId());
         jwtUtil.saveRefreshToken(member.getLoginId(), refreshToken);
         jwtUtil.sendAccessAndRefreshToken(response, accessToken, refreshToken);
@@ -108,7 +120,7 @@ public class MemberService implements UserDetailsService {
 
         return User.builder()
                 .username(member.getLoginId())
-                .password(member.getPassword())
+                .password(member.getPassword() != null ? member.getPassword() : "")
                 .build();
     }
 }

--- a/src/main/java/com/example/playlist/post/controller/PostController.java
+++ b/src/main/java/com/example/playlist/post/controller/PostController.java
@@ -1,0 +1,67 @@
+package com.example.playlist.post.controller;
+
+import com.example.playlist.global.success.SuccessResponse;
+import com.example.playlist.post.dto.PostAnswerRequest;
+import com.example.playlist.post.dto.PostRequest;
+import com.example.playlist.post.dto.PostResponse;
+import com.example.playlist.post.exception.PostSuccessCode;
+import com.example.playlist.post.service.PostService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class PostController {
+
+    private final PostService postService;
+
+    /** 문의 등록 */
+    @PostMapping("/posts")
+    public ResponseEntity<SuccessResponse<PostResponse>> createPost(
+            @RequestBody @Valid PostRequest request,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        PostResponse response = postService.createPost(request, userDetails.getUsername());
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(SuccessResponse.of(PostSuccessCode.POST_CREATED, response));
+    }
+
+    /** 내 문의 상세 조회 */
+    @GetMapping("/posts/{id}")
+    public ResponseEntity<SuccessResponse<PostResponse>> getPostDetail(
+            @PathVariable Long id,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        PostResponse response = postService.getPostDetail(id, userDetails.getUsername());
+        return ResponseEntity.ok(SuccessResponse.of(PostSuccessCode.POST_DETAIL, response));
+    }
+
+    /** 어드민: 전체 문의 목록 */
+    @GetMapping("/admin/posts")
+    public ResponseEntity<SuccessResponse<List<PostResponse>>> getAllPosts() {
+        return ResponseEntity.ok(SuccessResponse.of(PostSuccessCode.POST_LIST, postService.getAllPosts()));
+    }
+
+    /** 어드민: 문의 상세 조회 */
+    @GetMapping("/admin/posts/{id}")
+    public ResponseEntity<SuccessResponse<PostResponse>> getAdminPostDetail(@PathVariable Long id) {
+        return ResponseEntity.ok(SuccessResponse.of(PostSuccessCode.POST_DETAIL, postService.getAdminPostDetail(id)));
+    }
+
+    /** 어드민: 답변 등록 */
+    @PutMapping("/admin/posts/{id}/answer")
+    public ResponseEntity<SuccessResponse<?>> answerPost(
+            @PathVariable Long id,
+            @RequestBody @Valid PostAnswerRequest request
+    ) {
+        postService.answerPost(id, request);
+        return ResponseEntity.ok(SuccessResponse.of(PostSuccessCode.POST_ANSWERED));
+    }
+}

--- a/src/main/java/com/example/playlist/post/dto/PostAnswerRequest.java
+++ b/src/main/java/com/example/playlist/post/dto/PostAnswerRequest.java
@@ -1,0 +1,11 @@
+package com.example.playlist.post.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class PostAnswerRequest {
+
+    @NotBlank(message = "답변 내용은 필수로 입력해야 합니다.")
+    private String answer;
+}

--- a/src/main/java/com/example/playlist/post/dto/PostRequest.java
+++ b/src/main/java/com/example/playlist/post/dto/PostRequest.java
@@ -1,0 +1,19 @@
+package com.example.playlist.post.dto;
+
+import com.example.playlist.post.entity.InquiryCategory;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class PostRequest {
+
+    @NotBlank(message = "제목은 필수로 입력해야 합니다.")
+    private String title;
+
+    @NotBlank(message = "내용은 필수로 입력해야 합니다.")
+    private String content;
+
+    @NotNull(message = "카테고리는 필수로 선택해야 합니다.")
+    private InquiryCategory category;
+}

--- a/src/main/java/com/example/playlist/post/dto/PostResponse.java
+++ b/src/main/java/com/example/playlist/post/dto/PostResponse.java
@@ -1,0 +1,33 @@
+package com.example.playlist.post.dto;
+
+import com.example.playlist.post.entity.InquiryCategory;
+import com.example.playlist.post.entity.InquiryStatus;
+import com.example.playlist.post.entity.Post;
+
+import java.time.LocalDateTime;
+
+public record PostResponse(
+        Long id,
+        Long memberId,
+        String title,
+        String content,
+        InquiryCategory category,
+        InquiryStatus status,
+        String answer,
+        LocalDateTime answeredAt,
+        LocalDateTime createdAt
+) {
+    public static PostResponse from(Post post) {
+        return new PostResponse(
+                post.getId(),
+                post.getMemberId(),
+                post.getTitle(),
+                post.getContent(),
+                post.getCategory(),
+                post.getStatus(),
+                post.getAnswer(),
+                post.getAnsweredAt(),
+                post.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/example/playlist/post/entity/InquiryCategory.java
+++ b/src/main/java/com/example/playlist/post/entity/InquiryCategory.java
@@ -1,0 +1,7 @@
+package com.example.playlist.post.entity;
+
+public enum InquiryCategory {
+    SERVICE_PROPOSAL,  // 서비스 제의
+    COMPLAINT,         // 불편사항
+    QUESTION           // 궁금증
+}

--- a/src/main/java/com/example/playlist/post/entity/InquiryStatus.java
+++ b/src/main/java/com/example/playlist/post/entity/InquiryStatus.java
@@ -1,0 +1,6 @@
+package com.example.playlist.post.entity;
+
+public enum InquiryStatus {
+    PENDING,   // 답변 대기
+    ANSWERED   // 답변 완료
+}

--- a/src/main/java/com/example/playlist/post/entity/Post.java
+++ b/src/main/java/com/example/playlist/post/entity/Post.java
@@ -1,0 +1,20 @@
+package com.example.playlist.post.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class Post {
+    private Long id;
+    private Long memberId;
+    private String title;
+    private String content;
+    private InquiryCategory category;
+    private InquiryStatus status;
+    private String answer;
+    private LocalDateTime answeredAt;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/example/playlist/post/exception/PostErrorCode.java
+++ b/src/main/java/com/example/playlist/post/exception/PostErrorCode.java
@@ -1,0 +1,17 @@
+package com.example.playlist.post.exception;
+
+import com.example.playlist.global.error.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum PostErrorCode implements ErrorCode {
+
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "문의를 찾을 수 없습니다."),
+    UNAUTHORIZED_POST_ACCESS(HttpStatus.FORBIDDEN, "본인의 문의만 조회할 수 있습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/example/playlist/post/exception/PostException.java
+++ b/src/main/java/com/example/playlist/post/exception/PostException.java
@@ -1,0 +1,9 @@
+package com.example.playlist.post.exception;
+
+import com.example.playlist.global.error.BaseException;
+
+public class PostException extends BaseException {
+    public PostException(PostErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/playlist/post/exception/PostSuccessCode.java
+++ b/src/main/java/com/example/playlist/post/exception/PostSuccessCode.java
@@ -1,0 +1,22 @@
+package com.example.playlist.post.exception;
+
+import com.example.playlist.global.success.SuccessCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum PostSuccessCode implements SuccessCode {
+
+    POST_CREATED(HttpStatus.CREATED, "문의가 등록되었습니다."),
+    POST_LIST(HttpStatus.OK, "문의 목록 조회 성공"),
+    POST_DETAIL(HttpStatus.OK, "문의 상세 조회 성공"),
+    POST_ANSWERED(HttpStatus.OK, "답변이 등록되었습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    PostSuccessCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/example/playlist/post/repository/PostMapper.java
+++ b/src/main/java/com/example/playlist/post/repository/PostMapper.java
@@ -1,0 +1,17 @@
+package com.example.playlist.post.repository;
+
+import com.example.playlist.post.entity.Post;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+@Mapper
+public interface PostMapper {
+    void insertPost(Post post);
+    Optional<Post> findById(@Param("id") Long id);
+    List<Post> findByMemberId(@Param("memberId") Long memberId);
+    List<Post> findAll();
+    void updateAnswer(@Param("id") Long id, @Param("answer") String answer);
+}

--- a/src/main/java/com/example/playlist/post/service/PostService.java
+++ b/src/main/java/com/example/playlist/post/service/PostService.java
@@ -1,0 +1,82 @@
+package com.example.playlist.post.service;
+
+import com.example.playlist.member.entity.Member;
+import com.example.playlist.member.exception.MemberErrorCode;
+import com.example.playlist.member.exception.MemberException;
+import com.example.playlist.member.repository.MemberMapper;
+import com.example.playlist.post.dto.PostAnswerRequest;
+import com.example.playlist.post.dto.PostRequest;
+import com.example.playlist.post.dto.PostResponse;
+import com.example.playlist.post.entity.InquiryStatus;
+import com.example.playlist.post.entity.Post;
+import com.example.playlist.post.exception.PostErrorCode;
+import com.example.playlist.post.exception.PostException;
+import com.example.playlist.post.repository.PostMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PostService {
+
+    private final PostMapper postMapper;
+    private final MemberMapper memberMapper;
+
+    public PostResponse createPost(PostRequest request, String loginId) {
+        Member member = memberMapper.findByLoginId(loginId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        Post post = Post.builder()
+                .memberId(member.getId())
+                .title(request.getTitle())
+                .content(request.getContent())
+                .category(request.getCategory())
+                .status(InquiryStatus.PENDING)
+                .build();
+
+        postMapper.insertPost(post);
+        return PostResponse.from(post);
+    }
+
+    @Transactional(readOnly = true)
+    public PostResponse getPostDetail(Long postId, String loginId) {
+        Member member = memberMapper.findByLoginId(loginId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        Post post = postMapper.findById(postId)
+                .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
+
+        if (!post.getMemberId().equals(member.getId())) {
+            throw new PostException(PostErrorCode.UNAUTHORIZED_POST_ACCESS);
+        }
+        return PostResponse.from(post);
+    }
+
+    /** 어드민: 전체 문의 목록 */
+    @Transactional(readOnly = true)
+    public List<PostResponse> getAllPosts() {
+        return postMapper.findAll().stream()
+                .map(PostResponse::from)
+                .toList();
+    }
+
+    /** 어드민: 문의 상세 조회 */
+    @Transactional(readOnly = true)
+    public PostResponse getAdminPostDetail(Long postId) {
+        return PostResponse.from(
+                postMapper.findById(postId)
+                        .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND))
+        );
+    }
+
+    /** 어드민: 답변 등록 */
+    public void answerPost(Long postId, PostAnswerRequest request) {
+        postMapper.findById(postId)
+                .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
+        postMapper.updateAnswer(postId, request.getAnswer());
+    }
+}

--- a/src/main/resources/mapper/MemberMapper.xml
+++ b/src/main/resources/mapper/MemberMapper.xml
@@ -5,8 +5,8 @@
 <mapper namespace="com.example.playlist.member.repository.MemberMapper">
 
     <insert id="save" useGeneratedKeys="true" keyProperty="id">
-        INSERT INTO member (login_id, email, password, nickname, name, gender, age, provider, profile_complete, created_at, updated_at, is_deleted)
-        VALUES (#{loginId}, #{email}, #{password}, #{nickname}, #{name}, #{gender}, #{age}, #{provider}, #{profileComplete}, #{createdAt}, #{updatedAt}, false)
+        INSERT INTO member (login_id, email, password, nickname, name, gender, age, provider, role, profile_complete, created_at, updated_at, is_deleted)
+        VALUES (#{loginId}, #{email}, #{password}, #{nickname}, #{name}, #{gender}, #{age}, #{provider}, #{role}, #{profileComplete}, #{createdAt}, #{updatedAt}, false)
     </insert>
 
     <select id="findById" resultType="com.example.playlist.member.entity.Member">

--- a/src/main/resources/mapper/PostMapper.xml
+++ b/src/main/resources/mapper/PostMapper.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.example.playlist.post.repository.PostMapper">
+
+    <insert id="insertPost" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO post (member_id, title, content, category, status, created_at)
+        VALUES (#{memberId}, #{title}, #{content}, #{category}, #{status}, NOW())
+    </insert>
+
+    <select id="findById" resultType="com.example.playlist.post.entity.Post">
+        SELECT id, member_id, title, content, category, status, answer, answered_at, created_at
+        FROM post
+        WHERE id = #{id}
+    </select>
+
+    <select id="findByMemberId" resultType="com.example.playlist.post.entity.Post">
+        SELECT id, member_id, title, content, category, status, answer, answered_at, created_at
+        FROM post
+        WHERE member_id = #{memberId}
+        ORDER BY created_at DESC
+    </select>
+
+    <select id="findAll" resultType="com.example.playlist.post.entity.Post">
+        SELECT id, member_id, title, content, category, status, answer, answered_at, created_at
+        FROM post
+        ORDER BY created_at DESC
+    </select>
+
+    <update id="updateAnswer">
+        UPDATE post
+        SET answer      = #{answer},
+            status      = 'ANSWERED',
+            answered_at = NOW()
+        WHERE id = #{id}
+    </update>
+
+</mapper>

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -9,6 +9,7 @@ CREATE TABLE IF NOT EXISTS member
     gender           VARCHAR(10),
     age              INTEGER,
     provider         VARCHAR(20)  DEFAULT 'LOCAL',
+    role             VARCHAR(10)  DEFAULT 'USER',
     profile_complete BOOLEAN      DEFAULT true,
     created_at       TIMESTAMP    DEFAULT NOW(),
     updated_at       TIMESTAMP    DEFAULT NOW(),
@@ -31,6 +32,20 @@ CREATE TABLE IF NOT EXISTS member_social
 -- ALTER TABLE member ADD COLUMN IF NOT EXISTS profile_complete BOOLEAN DEFAULT true;
 -- ALTER TABLE member ALTER COLUMN password DROP NOT NULL;
 -- ALTER TABLE member ALTER COLUMN nickname DROP NOT NULL;
+-- ALTER TABLE member ADD COLUMN IF NOT EXISTS role VARCHAR(10) DEFAULT 'USER';
+
+CREATE TABLE IF NOT EXISTS post
+(
+    id          BIGSERIAL PRIMARY KEY,
+    member_id   BIGINT       NOT NULL REFERENCES member (id) ON DELETE CASCADE,
+    title       VARCHAR(255) NOT NULL,
+    content     TEXT         NOT NULL,
+    category    VARCHAR(30)  NOT NULL,
+    status      VARCHAR(20)  DEFAULT 'PENDING',
+    answer      TEXT,
+    answered_at TIMESTAMP,
+    created_at  TIMESTAMP    DEFAULT NOW()
+);
 
 CREATE TABLE IF NOT EXISTS playlist
 (


### PR DESCRIPTION
## 개요

사용자가 마이페이지에서 자신의 정보를 조회하고, 문의하기를 통해 서비스 제의 / 불편사항 / 궁금증을 남길 수 있는 기능을 구현했습니다.
관리자는 어드민 페이지에서 전체 문의를 확인하고 답변을 남길 수 있습니다.

---

## 변경 사항

### 1. 회원 Role 추가 (USER / ADMIN)

**`Role.java`** (신규)
- `USER`, `ADMIN` 두 가지 권한 enum 추가

**`Member.java`** 수정
- `role` 필드 추가
- `createMember()`, `createSocialMember()` 팩토리 메서드에 기본값 `Role.USER` 설정

**`schema.sql`** 수정
- `member` 테이블에 `role VARCHAR(10) DEFAULT 'USER'` 컬럼 추가

> 기존 DB에는 마이그레이션 필요:
> ```sql
> ALTER TABLE member ADD COLUMN IF NOT EXISTS role VARCHAR(10) DEFAULT 'USER';
> ```

---

### 2. JWT에 Role 정보 포함

**`JwtUtil.java`** 수정
- `createAccessToken(loginId, role)` — role claim 추가
- `extractRole(token)` — 토큰에서 role 추출 메서드 추가

**`JwtFilter.java`** 수정
- Access Token에서 role 추출 → `ROLE_USER` / `ROLE_ADMIN` authorities로 SecurityContext 설정
- Refresh Token 재발급 시 DB에서 role 조회 후 새 Access Token에 포함

**`SecurityConfig.java`** 수정
- `/admin/**` 경로에 `ROLE_ADMIN`만 접근 가능하도록 설정

**`OAuth2SuccessHandler.java`**, **`CustomOAuth2UserService.java`**, **`CustomOAuth2User.java`** 수정
- 소셜 로그인 성공 시에도 role을 Access Token에 포함

---

### 3. 마이페이지 조회

**새 엔드포인트**
```
GET /members/mypage
```

**응답 예시**
```json
{
  "name": "홍길동",
  "email": "hong@example.com",
  "age": 25,
  "gender": "MALE",
  "playlists": [
    { "id": 1, "name": "힐링 플레이리스트", "prompt": "잔잔한 음악", "createdAt": "..." }
  ],
  "posts": [
    { "id": 1, "title": "문의드립니다", "category": "QUESTION", "status": "PENDING", "createdAt": "..." }
  ]
}
```

**`MyPageResponse.java`**, **`PlaylistSummaryResponse.java`**, **`PostSummaryResponse.java`** (신규 DTO)

**`MemberService.java`** 수정
- `getMyPage(loginId)` 메서드 추가 — 회원 정보 + 플레이리스트 목록 + 문의 목록 한 번에 반환

---

### 4. 문의하기(Post) 기능

#### DB 테이블 추가 (`schema.sql`)
```sql
CREATE TABLE IF NOT EXISTS post (
    id          BIGSERIAL PRIMARY KEY,
    member_id   BIGINT       NOT NULL REFERENCES member(id) ON DELETE CASCADE,
    title       VARCHAR(255) NOT NULL,
    content     TEXT         NOT NULL,
    category    VARCHAR(30)  NOT NULL,   -- SERVICE_PROPOSAL / COMPLAINT / QUESTION
    status      VARCHAR(20)  DEFAULT 'PENDING',  -- PENDING / ANSWERED
    answer      TEXT,
    answered_at TIMESTAMP,
    created_at  TIMESTAMP    DEFAULT NOW()
);
```

#### 신규 enum
- `InquiryCategory` — `SERVICE_PROPOSAL`(서비스 제의) / `COMPLAINT`(불편사항) / `QUESTION`(궁금증)
- `InquiryStatus` — `PENDING`(답변 대기) / `ANSWERED`(답변 완료)

#### API 엔드포인트

| Method | URL | 권한 | 설명 |
|--------|-----|------|------|
| `POST` | `/posts` | 로그인 사용자 | 문의 등록 |
| `GET` | `/posts/{id}` | 로그인 사용자 | 내 문의 상세 조회 (본인 것만 가능) |
| `GET` | `/admin/posts` | ADMIN | 전체 문의 목록 조회 |
| `GET` | `/admin/posts/{id}` | ADMIN | 문의 상세 조회 |
| `PUT` | `/admin/posts/{id}/answer` | ADMIN | 답변 등록 |

#### 요청/응답 예시

**문의 등록 요청**
```json
{
  "title": "사용이 불편합니다",
  "content": "검색 기능이 잘 안 됩니다.",
  "category": "COMPLAINT"
}
```

**문의 상세 응답 (답변 후)**
```json
{
  "id": 1,
  "title": "사용이 불편합니다",
  "content": "검색 기능이 잘 안 됩니다.",
  "category": "COMPLAINT",
  "status": "ANSWERED",
  "answer": "불편을 드려 죄송합니다. 다음 업데이트에서 개선 예정입니다.",
  "answeredAt": "2026-04-21T15:30:00",
  "createdAt": "2026-04-21T10:00:00"
}
```

---

## ADMIN 권한 부여 방법

Role 변경 엔드포인트는 별도로 없으며, DB에서 직접 수정합니다:
```sql
UPDATE member SET role = 'ADMIN' WHERE login_id = '관리자아이디';
```

---

## 테스트 체크리스트

- [ ] 일반 회원으로 로그인 후 `GET /members/mypage` 조회 확인
- [ ] 문의 등록 (`POST /posts`) 후 마이페이지에서 목록 확인
- [ ] 본인 문의 외 다른 문의 조회 시 403 반환 확인
- [ ] ADMIN 계정으로 전체 문의 목록 조회 확인
- [ ] ADMIN 계정으로 답변 등록 후 status `ANSWERED` 변경 확인
- [ ] 일반 USER가 `/admin/**` 접근 시 403 반환 확인

🤖 Generated with [Claude Code](https://claude.ai/claude-code)