### PR TITLE
feat: 음악 퀴즈 게임 기능 추가 + Spotify 검색 빈 결과 버그 수정

### DIFF
--- a/src/main/java/com/example/playlist/game/controller/GameController.java
+++ b/src/main/java/com/example/playlist/game/controller/GameController.java
@@ -1,0 +1,30 @@
+package com.example.playlist.game.controller;
+
+import com.example.playlist.game.dto.QuizTrackResponse;
+import com.example.playlist.game.service.GameService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/game")
+@RequiredArgsConstructor
+public class GameController {
+
+    private final GameService gameService;
+
+    @Operation(
+            summary = "퀴즈 트랙 조회",
+            description = "연대별 랜덤 트랙 반환 (미리듣기 URL 포함). decade: 1990 / 2000 / 2010 / 2020"
+    )
+    @GetMapping("/quiz")
+    public ResponseEntity<QuizTrackResponse> getQuizTrack(
+            @RequestParam int decade
+    ) {
+        return ResponseEntity.ok(gameService.getQuizTrack(decade));
+    }
+}

--- a/src/main/java/com/example/playlist/game/dto/QuizTrackResponse.java
+++ b/src/main/java/com/example/playlist/game/dto/QuizTrackResponse.java
@@ -1,0 +1,33 @@
+package com.example.playlist.game.dto;
+
+import com.example.playlist.spotify.dto.SpotifySearchResponse;
+
+import java.util.List;
+
+public record QuizTrackResponse(
+        String trackId,
+        String previewUrl,
+        String title,
+        String artist,
+        String albumImageUrl
+) {
+    public static QuizTrackResponse from(SpotifySearchResponse.Item item) {
+        String artist = item.getArtists() != null && !item.getArtists().isEmpty()
+                ? item.getArtists().get(0).getName()
+                : "Unknown";
+
+        String imageUrl = null;
+        List<SpotifySearchResponse.AlbumImage> images = item.getAlbum().getImages();
+        if (images != null && !images.isEmpty()) {
+            imageUrl = images.get(0).getUrl();
+        }
+
+        return new QuizTrackResponse(
+                item.getTrackId(),
+                item.getPreviewUrl(),
+                item.getName(),
+                artist,
+                imageUrl
+        );
+    }
+}

--- a/src/main/java/com/example/playlist/game/service/GameService.java
+++ b/src/main/java/com/example/playlist/game/service/GameService.java
@@ -1,0 +1,82 @@
+package com.example.playlist.game.service;
+
+import com.example.playlist.game.dto.QuizTrackResponse;
+import com.example.playlist.spotify.dto.SpotifySearchResponse;
+import com.example.playlist.spotify.service.SpotifyTokenService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+import java.util.Random;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GameService {
+
+    private final SpotifyTokenService spotifyTokenService;
+    private final WebClient spotifyWebClient;
+    private final Random random = new Random();
+
+    private static final int SEARCH_LIMIT = 50;
+
+    /**
+     * 연대별 랜덤 퀴즈 트랙 반환 (preview_url 있는 것만)
+     * decade: 1990 / 2000 / 2010 / 2020
+     */
+    public QuizTrackResponse getQuizTrack(int decade) {
+        String yearRange = toYearRange(decade);
+        String accessToken = spotifyTokenService.getAccessToken();
+
+        // 랜덤 offset으로 다양한 곡 제공 (최대 200 범위)
+        int offset = random.nextInt(200);
+
+        List<SpotifySearchResponse.Item> candidates = searchWithPreview(yearRange, accessToken, offset);
+
+        // 결과가 없으면 offset=0으로 재시도
+        if (candidates.isEmpty()) {
+            log.info("[Game] preview_url 없음, offset=0 재시도 - yearRange={}", yearRange);
+            candidates = searchWithPreview(yearRange, accessToken, 0);
+        }
+
+        if (candidates.isEmpty()) {
+            throw new IllegalStateException("해당 연대의 미리듣기 가능한 트랙을 찾을 수 없습니다.");
+        }
+
+        SpotifySearchResponse.Item picked = candidates.get(random.nextInt(candidates.size()));
+        log.info("[Game] 퀴즈 트랙 선택 - decade={}, title={}", decade, picked.getName());
+
+        return QuizTrackResponse.from(picked);
+    }
+
+    private List<SpotifySearchResponse.Item> searchWithPreview(String yearRange, String accessToken, int offset) {
+        SpotifySearchResponse response = spotifyWebClient
+                .get()
+                .uri("/search?q=year:{year}&type=track&limit={limit}&offset={offset}&market=KR",
+                        yearRange, SEARCH_LIMIT, offset)
+                .header("Authorization", "Bearer " + accessToken)
+                .retrieve()
+                .bodyToMono(SpotifySearchResponse.class)
+                .block();
+
+        if (response == null || response.getTracks() == null || response.getTracks().getItems() == null) {
+            return List.of();
+        }
+
+        return response.getTracks().getItems().stream()
+                .filter(item -> item.getPreviewUrl() != null && !item.getPreviewUrl().isBlank())
+                .toList();
+    }
+
+    private String toYearRange(int decade) {
+        return switch (decade) {
+            case 1990 -> "1990-1999";
+            case 2000 -> "2000-2009";
+            case 2010 -> "2010-2019";
+            case 2020 -> "2020-2029";
+            default -> throw new IllegalArgumentException("지원하지 않는 연대입니다: " + decade);
+        };
+    }
+}

--- a/src/main/java/com/example/playlist/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/playlist/global/config/SecurityConfig.java
@@ -72,6 +72,7 @@ public class SecurityConfig {
                         .requestMatchers("/members/profile/complete").permitAll()
                         .requestMatchers("/oauth2/**", "/login/oauth2/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/game/**").permitAll()
                         .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/example/playlist/spotify/dto/SpotifySearchResponse.java
+++ b/src/main/java/com/example/playlist/spotify/dto/SpotifySearchResponse.java
@@ -23,6 +23,9 @@ public class SpotifySearchResponse {
 
         private String name;
 
+        @JsonProperty("preview_url")
+        private String previewUrl;
+
         private List<Artist> artists;
 
         private Album album;

--- a/src/main/java/com/example/playlist/spotify/service/SpotifyService.java
+++ b/src/main/java/com/example/playlist/spotify/service/SpotifyService.java
@@ -36,7 +36,16 @@ public class SpotifyService {
                 .header("Authorization", "Bearer " + accessToken)
                 .retrieve()
                 .bodyToMono(SpotifySearchResponse.class)
-                .map(response -> SpotifyTrack.from(response.getTracks().getItems().get(0), title, artist));
+                .flatMap(response -> {
+                    List<SpotifySearchResponse.Item> items = response.getTracks() != null
+                            ? response.getTracks().getItems()
+                            : null;
+                    if (items == null || items.isEmpty()) {
+                        log.warn("[Spotify] 검색 결과 없음 - artist={}, title={}", artist, title);
+                        return Mono.empty();
+                    }
+                    return Mono.just(SpotifyTrack.from(items.get(0), title, artist));
+                });
     }
 
     // ─────────────────────────────────────────────


### PR DESCRIPTION
- GET /game/quiz?decade=1990|2000|2010|2020 엔드포인트 추가
  - Spotify year: 필터로 연대별 랜덤 트랙 반환
  - preview_url이 있는 트랙만 필터링 (30초 미리듣기)
  - 랜덤 offset(0~200) 적용, 결과 없을 시 offset=0으로 재시도
- SpotifySearchResponse에 preview_url 필드 추가
- SpotifyService.searchTrack() IndexOutOfBoundsException 수정
  - 검색 결과 없을 때 get(0) 호출로 발생하던 에러 → Mono.empty() 반환으로 처리
- SecurityConfig에 /game/** permitAll() 추가 (인증 없이 접근 가능)