### PR TITLE
fix: GameService URI 템플릿 치환 오류 수정 (Invalid limit)

### DIFF
--- a/src/main/java/com/example/playlist/game/service/GameService.java
+++ b/src/main/java/com/example/playlist/game/service/GameService.java
@@ -54,8 +54,14 @@ public class GameService {
     private List<SpotifySearchResponse.Item> searchWithPreview(String yearRange, String accessToken, int offset) {
         SpotifySearchResponse response = spotifyWebClient
                 .get()
-                .uri("/search?q=year:{year}&type=track&limit={limit}&offset={offset}&market=KR",
-                        yearRange, SEARCH_LIMIT, offset)
+                .uri(uriBuilder -> uriBuilder
+                        .path("/search")
+                        .queryParam("q", "year:" + yearRange)
+                        .queryParam("type", "track")
+                        .queryParam("limit", SEARCH_LIMIT)
+                        .queryParam("offset", offset)
+                        .queryParam("market", "KR")
+                        .build())
                 .header("Authorization", "Bearer " + accessToken)
                 .retrieve()
                 .bodyToMono(SpotifySearchResponse.class)


### PR DESCRIPTION
q=year:{year} 패턴에서 콜론으로 인한 positional 치환 오류 발생
→ UriBuilder 람다로 교체하여 파라미터를 명시적으로 분리