### PR TITLE
fix: GameService URI 템플릿 재수정 - q 파라미터로 분리

### DIFF
--- a/src/main/java/com/example/playlist/game/service/GameService.java
+++ b/src/main/java/com/example/playlist/game/service/GameService.java
@@ -54,14 +54,8 @@ public class GameService {
     private List<SpotifySearchResponse.Item> searchWithPreview(String yearRange, String accessToken, int offset) {
         SpotifySearchResponse response = spotifyWebClient
                 .get()
-                .uri(uriBuilder -> uriBuilder
-                        .path("/search")
-                        .queryParam("q", "year:" + yearRange)
-                        .queryParam("type", "track")
-                        .queryParam("limit", SEARCH_LIMIT)
-                        .queryParam("offset", offset)
-                        .queryParam("market", "KR")
-                        .build())
+                .uri("/search?q={q}&type=track&limit={limit}&offset={offset}&market=KR",
+                        "year:" + yearRange, SEARCH_LIMIT, offset)
                 .header("Authorization", "Bearer " + accessToken)
                 .retrieve()
                 .bodyToMono(SpotifySearchResponse.class)


### PR DESCRIPTION
year:{year} 패턴의 콜론으로 인한 치환 오류를
q={q} 단일 변수로 분리하여 해결
기존 SpotifyService와 동일한 방식으로 통일