### PR TITLE
feat: 퀴즈 게임 DB 저장 방식으로 전환

### DIFF
--- a/src/main/java/com/example/playlist/game/controller/GameController.java
+++ b/src/main/java/com/example/playlist/game/controller/GameController.java
@@ -1,30 +1,40 @@
 package com.example.playlist.game.controller;
 
+import com.example.playlist.game.dto.CollectResponse;
 import com.example.playlist.game.dto.QuizTrackResponse;
+import com.example.playlist.game.service.GameCollectService;
 import com.example.playlist.game.service.GameService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/game")
 @RequiredArgsConstructor
 public class GameController {
 
     private final GameService gameService;
+    private final GameCollectService gameCollectService;
 
     @Operation(
             summary = "퀴즈 트랙 조회",
-            description = "연대별 랜덤 트랙 반환 (미리듣기 URL 포함). decade: 1990 / 2000 / 2010 / 2020"
+            description = "연대별 랜덤 트랙 반환. decade: 1990 / 2000 / 2010 / 2020"
     )
-    @GetMapping("/quiz")
+    @GetMapping("/game/quiz")
     public ResponseEntity<QuizTrackResponse> getQuizTrack(
             @RequestParam int decade
     ) {
         return ResponseEntity.ok(gameService.getQuizTrack(decade));
+    }
+
+    @Operation(
+            summary = "[Admin] 퀴즈 트랙 수집",
+            description = "연대별 한국 노래 100곡을 Spotify + Deezer에서 수집해 DB에 저장. decade: 1990 / 2000 / 2010 / 2020"
+    )
+    @PostMapping("/admin/game/collect")
+    public ResponseEntity<CollectResponse> collectTracks(
+            @RequestParam int decade
+    ) {
+        return ResponseEntity.ok(gameCollectService.collectTracks(decade));
     }
 }

--- a/src/main/java/com/example/playlist/game/dto/CollectResponse.java
+++ b/src/main/java/com/example/playlist/game/dto/CollectResponse.java
@@ -1,0 +1,7 @@
+package com.example.playlist.game.dto;
+
+public record CollectResponse(
+        int decade,
+        int newlyCollected,
+        int totalInDb
+) {}

--- a/src/main/java/com/example/playlist/game/dto/QuizTrackResponse.java
+++ b/src/main/java/com/example/playlist/game/dto/QuizTrackResponse.java
@@ -1,5 +1,6 @@
 package com.example.playlist.game.dto;
 
+import com.example.playlist.game.entity.QuizTrack;
 import com.example.playlist.spotify.dto.SpotifySearchResponse;
 
 import java.util.List;
@@ -11,6 +12,16 @@ public record QuizTrackResponse(
         String artist,
         String albumImageUrl
 ) {
+    public static QuizTrackResponse fromEntity(QuizTrack track) {
+        return new QuizTrackResponse(
+                track.getSpotifyTrackId(),
+                track.getPreviewUrl(),
+                track.getTitle(),
+                track.getArtist(),
+                track.getAlbumImageUrl()
+        );
+    }
+
     public static QuizTrackResponse from(SpotifySearchResponse.Item item, String previewUrl) {
         String artist = item.getArtists() != null && !item.getArtists().isEmpty()
                 ? item.getArtists().get(0).getName()

--- a/src/main/java/com/example/playlist/game/entity/QuizTrack.java
+++ b/src/main/java/com/example/playlist/game/entity/QuizTrack.java
@@ -1,0 +1,19 @@
+package com.example.playlist.game.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class QuizTrack {
+    private Long id;
+    private String title;
+    private String artist;
+    private String albumImageUrl;
+    private String previewUrl;
+    private int decade;
+    private String spotifyTrackId;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/example/playlist/game/repository/QuizTrackMapper.java
+++ b/src/main/java/com/example/playlist/game/repository/QuizTrackMapper.java
@@ -1,0 +1,13 @@
+package com.example.playlist.game.repository;
+
+import com.example.playlist.game.entity.QuizTrack;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface QuizTrackMapper {
+    void insert(QuizTrack track);
+    boolean existsBySpotifyTrackId(@Param("spotifyTrackId") String spotifyTrackId);
+    QuizTrack findRandomByDecade(@Param("decade") int decade);
+    int countByDecade(@Param("decade") int decade);
+}

--- a/src/main/java/com/example/playlist/game/service/GameCollectService.java
+++ b/src/main/java/com/example/playlist/game/service/GameCollectService.java
@@ -1,0 +1,144 @@
+package com.example.playlist.game.service;
+
+import com.example.playlist.game.dto.CollectResponse;
+import com.example.playlist.game.dto.DeezerSearchResponse;
+import com.example.playlist.game.entity.QuizTrack;
+import com.example.playlist.game.repository.QuizTrackMapper;
+import com.example.playlist.spotify.dto.SpotifySearchResponse;
+import com.example.playlist.spotify.service.SpotifyTokenService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GameCollectService {
+
+    private final SpotifyTokenService spotifyTokenService;
+    private final WebClient spotifyWebClient;
+    private final WebClient deezerWebClient;
+    private final QuizTrackMapper quizTrackMapper;
+
+    private static final int SEARCH_LIMIT = 10;
+    private static final int TARGET = 100;
+    private static final int MIN_POPULARITY = 20;
+    private static final int MAX_OFFSET = 500; // 최대 500곡 탐색
+
+    public CollectResponse collectTracks(int decade) {
+        String yearRange = toYearRange(decade);
+        String accessToken = spotifyTokenService.getAccessToken();
+
+        int newlyCollected = 0;
+        int offset = 0;
+
+        while (newlyCollected < TARGET && offset < MAX_OFFSET) {
+            List<SpotifySearchResponse.Item> items = searchSpotify(yearRange, accessToken, offset);
+
+            if (items.isEmpty()) {
+                log.info("[Collect] Spotify 결과 없음, offset={}", offset);
+                break;
+            }
+
+            for (SpotifySearchResponse.Item item : items) {
+                if (newlyCollected >= TARGET) break;
+                if (item.getPopularity() < MIN_POPULARITY) continue;
+
+                // 이미 DB에 있으면 스킵
+                if (quizTrackMapper.existsBySpotifyTrackId(item.getTrackId())) {
+                    log.debug("[Collect] 중복 스킵 - title={}", item.getName());
+                    continue;
+                }
+
+                String artist = item.getArtists() != null && !item.getArtists().isEmpty()
+                        ? item.getArtists().get(0).getName() : "";
+
+                // Deezer preview 확인
+                String previewUrl = getDeezerPreview(item.getName(), artist);
+                if (previewUrl == null) {
+                    log.debug("[Collect] Deezer preview 없음 - title={}", item.getName());
+                    continue;
+                }
+
+                String albumImageUrl = null;
+                if (item.getAlbum() != null && item.getAlbum().getImages() != null
+                        && !item.getAlbum().getImages().isEmpty()) {
+                    albumImageUrl = item.getAlbum().getImages().get(0).getUrl();
+                }
+
+                quizTrackMapper.insert(QuizTrack.builder()
+                        .title(item.getName())
+                        .artist(artist)
+                        .albumImageUrl(albumImageUrl)
+                        .previewUrl(previewUrl)
+                        .decade(decade)
+                        .spotifyTrackId(item.getTrackId())
+                        .build());
+
+                newlyCollected++;
+                log.info("[Collect] 저장 - [{}/{}] title={}, artist={}, popularity={}",
+                        newlyCollected, TARGET, item.getName(), artist, item.getPopularity());
+            }
+
+            offset += SEARCH_LIMIT;
+        }
+
+        int total = quizTrackMapper.countByDecade(decade);
+        log.info("[Collect] 완료 - decade={}, 신규={}, DB총={}", decade, newlyCollected, total);
+        return new CollectResponse(decade, newlyCollected, total);
+    }
+
+    private List<SpotifySearchResponse.Item> searchSpotify(String yearRange, String accessToken, int offset) {
+        try {
+            SpotifySearchResponse response = spotifyWebClient
+                    .get()
+                    .uri("/search?q={q}&type=track&limit={limit}&offset={offset}&market=KR",
+                            "year:" + yearRange + " genre:k-pop", SEARCH_LIMIT, offset)
+                    .header("Authorization", "Bearer " + accessToken)
+                    .retrieve()
+                    .bodyToMono(SpotifySearchResponse.class)
+                    .block();
+
+            if (response == null || response.getTracks() == null || response.getTracks().getItems() == null) {
+                return List.of();
+            }
+            return response.getTracks().getItems();
+        } catch (Exception e) {
+            log.warn("[Collect] Spotify 검색 실패 - offset={}, error={}", offset, e.getMessage());
+            return List.of();
+        }
+    }
+
+    private String getDeezerPreview(String title, String artist) {
+        try {
+            DeezerSearchResponse response = deezerWebClient
+                    .get()
+                    .uri("/search?q={q}&limit=1", artist + " " + title)
+                    .retrieve()
+                    .bodyToMono(DeezerSearchResponse.class)
+                    .block();
+
+            if (response == null || response.getData() == null || response.getData().isEmpty()) {
+                return null;
+            }
+            String preview = response.getData().get(0).getPreview();
+            return (preview != null && !preview.isBlank()) ? preview : null;
+        } catch (Exception e) {
+            log.warn("[Collect] Deezer 조회 실패 - title={}, error={}", title, e.getMessage());
+            return null;
+        }
+    }
+
+    private String toYearRange(int decade) {
+        return switch (decade) {
+            case 1990 -> "1990-1999";
+            case 2000 -> "2000-2009";
+            case 2010 -> "2010-2019";
+            case 2020 -> "2020-2029";
+            default -> throw new IllegalArgumentException("지원하지 않는 연대입니다: " + decade);
+        };
+    }
+}

--- a/src/main/java/com/example/playlist/game/service/GameService.java
+++ b/src/main/java/com/example/playlist/game/service/GameService.java
@@ -1,118 +1,25 @@
 package com.example.playlist.game.service;
 
-import com.example.playlist.game.dto.DeezerSearchResponse;
 import com.example.playlist.game.dto.QuizTrackResponse;
-import com.example.playlist.spotify.dto.SpotifySearchResponse;
-import com.example.playlist.spotify.service.SpotifyTokenService;
+import com.example.playlist.game.entity.QuizTrack;
+import com.example.playlist.game.repository.QuizTrackMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.web.reactive.function.client.WebClient;
-
-import java.util.*;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class GameService {
 
-    private final SpotifyTokenService spotifyTokenService;
-    private final WebClient spotifyWebClient;
-    private final WebClient deezerWebClient;
-    private final Random random = new Random();
-
-    private static final int SEARCH_LIMIT = 10;
-    private static final int MIN_POPULARITY = 40;
-    private static final int MAX_OFFSET = 150;
+    private final QuizTrackMapper quizTrackMapper;
 
     public QuizTrackResponse getQuizTrack(int decade) {
-        String yearRange = toYearRange(decade);
-        String accessToken = spotifyTokenService.getAccessToken();
-
-        // 서로 다른 offset으로 2회 검색 → 최대 20곡 풀 구성
-        Set<String> seenIds = new HashSet<>();
-        List<SpotifySearchResponse.Item> pool = new ArrayList<>();
-
-        int offset1 = random.nextInt(MAX_OFFSET);
-        int offset2 = random.nextInt(MAX_OFFSET);
-
-        for (int offset : new int[]{offset1, offset2}) {
-            searchSpotify(yearRange, accessToken, offset).stream()
-                    .filter(item -> item.getPopularity() >= MIN_POPULARITY)
-                    .filter(item -> seenIds.add(item.getTrackId()))
-                    .forEach(pool::add);
+        QuizTrack track = quizTrackMapper.findRandomByDecade(decade);
+        if (track == null) {
+            throw new IllegalStateException("해당 연대의 트랙이 없습니다. 관리자 페이지에서 곡을 수집해주세요.");
         }
-
-        // popularity 기준 미달 시 offset=0으로 제한 없이 재시도
-        if (pool.isEmpty()) {
-            log.info("[Game] popularity 기준 미달, offset=0 재시도 - yearRange={}", yearRange);
-            pool = searchSpotify(yearRange, accessToken, 0);
-        }
-
-        if (pool.isEmpty()) {
-            throw new IllegalStateException("해당 연대의 트랙을 찾을 수 없습니다.");
-        }
-
-        // popularity 내림차순 정렬 후 상위 절반에서 랜덤 선택 (인기곡 위주 + 다양성 확보)
-        pool.sort((a, b) -> b.getPopularity() - a.getPopularity());
-        int pickRange = Math.max(1, pool.size() / 2);
-        SpotifySearchResponse.Item picked = pool.get(random.nextInt(pickRange));
-
-        String artist = picked.getArtists() != null && !picked.getArtists().isEmpty()
-                ? picked.getArtists().get(0).getName() : "";
-
-        String previewUrl = getDeezerPreview(picked.getName(), artist);
-        log.info("[Game] 퀴즈 트랙 선택 - decade={}, title={}, artist={}, popularity={}",
-                decade, picked.getName(), artist, picked.getPopularity());
-
-        return QuizTrackResponse.from(picked, previewUrl);
-    }
-
-    private List<SpotifySearchResponse.Item> searchSpotify(String yearRange, String accessToken, int offset) {
-        SpotifySearchResponse response = spotifyWebClient
-                .get()
-                .uri("/search?q={q}&type=track&limit={limit}&offset={offset}&market=KR",
-                        "year:" + yearRange + " genre:k-pop", SEARCH_LIMIT, offset)
-                .header("Authorization", "Bearer " + accessToken)
-                .retrieve()
-                .bodyToMono(SpotifySearchResponse.class)
-                .block();
-
-        if (response == null || response.getTracks() == null || response.getTracks().getItems() == null) {
-            return List.of();
-        }
-
-        return response.getTracks().getItems();
-    }
-
-    private String getDeezerPreview(String title, String artist) {
-        try {
-            DeezerSearchResponse response = deezerWebClient
-                    .get()
-                    .uri("/search?q={q}&limit=1", artist + " " + title)
-                    .retrieve()
-                    .bodyToMono(DeezerSearchResponse.class)
-                    .block();
-
-            if (response == null || response.getData() == null || response.getData().isEmpty()) {
-                return null;
-            }
-
-            String preview = response.getData().get(0).getPreview();
-            return (preview != null && !preview.isBlank()) ? preview : null;
-        } catch (Exception e) {
-            log.warn("[Game] Deezer 조회 실패 - title={}, error={}", title, e.getMessage());
-            return null;
-        }
-    }
-
-    private String toYearRange(int decade) {
-        return switch (decade) {
-            case 1990 -> "1990-1999";
-            case 2000 -> "2000-2009";
-            case 2010 -> "2010-2019";
-            case 2020 -> "2020-2029";
-            default -> throw new IllegalArgumentException("지원하지 않는 연대입니다: " + decade);
-        };
+        log.info("[Game] 퀴즈 트랙 반환 - decade={}, title={}, artist={}", decade, track.getTitle(), track.getArtist());
+        return QuizTrackResponse.fromEntity(track);
     }
 }

--- a/src/main/resources/mapper/QuizTrackMapper.xml
+++ b/src/main/resources/mapper/QuizTrackMapper.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.example.playlist.game.repository.QuizTrackMapper">
+
+    <insert id="insert" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO quiz_track (title, artist, album_image_url, preview_url, decade, spotify_track_id)
+        VALUES (#{title}, #{artist}, #{albumImageUrl}, #{previewUrl}, #{decade}, #{spotifyTrackId})
+    </insert>
+
+    <select id="existsBySpotifyTrackId" resultType="boolean">
+        SELECT COUNT(*) > 0
+        FROM quiz_track
+        WHERE spotify_track_id = #{spotifyTrackId}
+    </select>
+
+    <select id="findRandomByDecade" resultType="com.example.playlist.game.entity.QuizTrack">
+        SELECT id, title, artist, album_image_url, preview_url, decade, spotify_track_id, created_at
+        FROM quiz_track
+        WHERE decade = #{decade}
+        ORDER BY RANDOM()
+        LIMIT 1
+    </select>
+
+    <select id="countByDecade" resultType="int">
+        SELECT COUNT(*)
+        FROM quiz_track
+        WHERE decade = #{decade}
+    </select>
+
+</mapper>

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -87,3 +87,15 @@ CREATE TABLE IF NOT EXISTS playlist_tag
     tag_id      BIGINT REFERENCES tag (id) ON DELETE CASCADE,
     PRIMARY KEY (playlist_id, tag_id)
 );
+
+CREATE TABLE IF NOT EXISTS quiz_track
+(
+    id                BIGSERIAL PRIMARY KEY,
+    title             VARCHAR(255) NOT NULL,
+    artist            VARCHAR(255) NOT NULL,
+    album_image_url   TEXT,
+    preview_url       TEXT         NOT NULL,
+    decade            INTEGER      NOT NULL,
+    spotify_track_id  VARCHAR(100) NOT NULL UNIQUE,
+    created_at        TIMESTAMP    DEFAULT NOW()
+);


### PR DESCRIPTION
- quiz_track 테이블 추가 (spotify_track_id UNIQUE로 중복 방지)
- QuizTrackMapper + QuizTrackMapper.xml 추가
  - insert, existsBySpotifyTrackId, findRandomByDecade, countByDecade
- GameCollectService 추가
  - POST /admin/game/collect?decade=XXXX (ADMIN 전용)
  - Spotify 검색 → Deezer preview 확인 → DB 저장 (100곡 목표)
  - 재호출 시 DB에 없는 곡만 추가 (중복 스킵)
  - popularity >= 20 필터
- GameService를 DB 랜덤 조회 방식으로 단순화
- QuizTrackResponse에 fromEntity() 팩토리 메서드 추가