### PR TITLE
Gemini→Deezer 퀴즈 방식으로 전환 및 정답 정규화 필드 추가

### DIFF
--- a/src/main/java/com/example/playlist/game/dto/DeezerSearchResponse.java
+++ b/src/main/java/com/example/playlist/game/dto/DeezerSearchResponse.java
@@ -1,5 +1,6 @@
 package com.example.playlist.game.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 
 import java.util.List;
@@ -12,5 +13,16 @@ public class DeezerSearchResponse {
     @Getter
     public static class DeezerTrack {
         private String preview;
+        private DeezerAlbum album;
+
+        public String getAlbumImageUrl() {
+            return album != null ? album.getCoverBig() : null;
+        }
+    }
+
+    @Getter
+    public static class DeezerAlbum {
+        @JsonProperty("cover_big")
+        private String coverBig;
     }
 }

--- a/src/main/java/com/example/playlist/game/dto/QuizTrackResponse.java
+++ b/src/main/java/com/example/playlist/game/dto/QuizTrackResponse.java
@@ -10,7 +10,9 @@ public record QuizTrackResponse(
         String previewUrl,
         String title,
         String artist,
-        String albumImageUrl
+        String albumImageUrl,
+        String titleNormalized,
+        String artistNormalized
 ) {
     public static QuizTrackResponse fromEntity(QuizTrack track) {
         return new QuizTrackResponse(
@@ -18,7 +20,9 @@ public record QuizTrackResponse(
                 track.getPreviewUrl(),
                 track.getTitle(),
                 track.getArtist(),
-                track.getAlbumImageUrl()
+                track.getAlbumImageUrl(),
+                normalize(track.getTitle()),
+                normalize(track.getArtist())
         );
     }
 
@@ -38,7 +42,26 @@ public record QuizTrackResponse(
                 previewUrl,
                 item.getName(),
                 artist,
-                imageUrl
+                imageUrl,
+                normalize(item.getName()),
+                normalize(artist)
         );
+    }
+
+    public static QuizTrackResponse fromGemini(String title, String artist, String previewUrl, String albumImageUrl) {
+        return new QuizTrackResponse(
+                null,
+                previewUrl,
+                title,
+                artist,
+                albumImageUrl,
+                normalize(title),
+                normalize(artist)
+        );
+    }
+
+    private static String normalize(String value) {
+        if (value == null) return null;
+        return value.replaceAll("\\s+", "").toLowerCase();
     }
 }

--- a/src/main/java/com/example/playlist/game/service/GameCollectService.java
+++ b/src/main/java/com/example/playlist/game/service/GameCollectService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Service
@@ -25,27 +26,49 @@ public class GameCollectService {
 
     private static final int SEARCH_LIMIT = 10;
     private static final int TARGET = 100;
-    private static final int MIN_POPULARITY = 0;
-    private static final int MAX_OFFSET = 500; // 최대 500곡 탐색
+
+    private static final Map<Integer, List<String>> KOREAN_ARTISTS = Map.of(
+        1990, List.of(
+            "서태지와 아이들", "김건모", "신승훈", "H.O.T.", "S.E.S.",
+            "god", "Fin.K.L", "젝스키스", "이승환", "조성모", "클론",
+            "박진영", "유승준", "룰라", "015B", "김광석", "이적",
+            "노이즈", "솔리드", "듀스", "DJ DOC", "토이", "패닉"
+        ),
+        2000, List.of(
+            "TVXQ", "Big Bang", "Wonder Girls", "Girls Generation", "2NE1",
+            "Super Junior", "KARA", "2PM", "SHINee", "BoA", "SS501",
+            "이효리", "비", "버즈", "브라운아이드걸스", "에픽하이",
+            "원더걸스", "f(x)", "씨스타", "4Minute", "지드래곤", "태양"
+        ),
+        2010, List.of(
+            "BTS", "EXO", "TWICE", "BLACKPINK", "Red Velvet",
+            "IU", "PSY", "INFINITE", "SISTAR", "GOT7", "Wanna One",
+            "NCT 127", "MAMAMOO", "AOA", "B2ST", "2AM", "케이윌",
+            "악동뮤지션", "볼빨간사춘기", "선미", "CL", "지코"
+        ),
+        2020, List.of(
+            "BTS", "BLACKPINK", "aespa", "IVE", "NewJeans",
+            "Stray Kids", "ITZY", "SEVENTEEN", "LE SSERAFIM", "NCT 127",
+            "ENHYPEN", "G I-DLE", "TXT", "ATEEZ", "Kep1er",
+            "NMIXX", "fromis 9", "BTOB", "임영웅", "이찬원"
+        )
+    );
 
     public CollectResponse collectTracks(int decade) {
         String yearRange = toYearRange(decade);
         String accessToken = spotifyTokenService.getAccessToken();
 
+        List<String> artists = KOREAN_ARTISTS.get(decade);
         int newlyCollected = 0;
-        int offset = 0;
 
-        while (newlyCollected < TARGET && offset < MAX_OFFSET) {
-            List<SpotifySearchResponse.Item> items = searchSpotify(yearRange, accessToken, offset);
+        for (String artist : artists) {
+            if (newlyCollected >= TARGET) break;
 
-            if (items.isEmpty()) {
-                log.info("[Collect] Spotify 결과 없음, offset={}", offset);
-                break;
-            }
+            List<SpotifySearchResponse.Item> items = searchSpotifyByArtist(artist, yearRange, accessToken);
+            log.info("[Collect] 아티스트={}, 결과={}곡", artist, items.size());
 
             for (SpotifySearchResponse.Item item : items) {
                 if (newlyCollected >= TARGET) break;
-                if (item.getPopularity() < MIN_POPULARITY) continue;
 
                 // 이미 DB에 있으면 스킵
                 if (quizTrackMapper.existsBySpotifyTrackId(item.getTrackId())) {
@@ -53,11 +76,11 @@ public class GameCollectService {
                     continue;
                 }
 
-                String artist = item.getArtists() != null && !item.getArtists().isEmpty()
+                String trackArtist = item.getArtists() != null && !item.getArtists().isEmpty()
                         ? item.getArtists().get(0).getName() : "";
 
                 // Deezer preview 확인
-                String previewUrl = getDeezerPreview(item.getName(), artist);
+                String previewUrl = getDeezerPreview(item.getName(), trackArtist);
                 if (previewUrl == null) {
                     log.debug("[Collect] Deezer preview 없음 - title={}", item.getName());
                     continue;
@@ -71,7 +94,7 @@ public class GameCollectService {
 
                 quizTrackMapper.insert(QuizTrack.builder()
                         .title(item.getName())
-                        .artist(artist)
+                        .artist(trackArtist)
                         .albumImageUrl(albumImageUrl)
                         .previewUrl(previewUrl)
                         .decade(decade)
@@ -80,13 +103,11 @@ public class GameCollectService {
 
                 newlyCollected++;
                 log.info("[Collect] 저장 - [{}/{}] title={}, artist={}, popularity={}",
-                        newlyCollected, TARGET, item.getName(), artist, item.getPopularity());
+                        newlyCollected, TARGET, item.getName(), trackArtist, item.getPopularity());
             }
 
-            offset += SEARCH_LIMIT;
-
             // Spotify rate limit 방지 딜레이
-            try { Thread.sleep(300); } catch (InterruptedException ignored) {}
+            try { Thread.sleep(200); } catch (InterruptedException ignored) {}
         }
 
         int total = quizTrackMapper.countByDecade(decade);
@@ -94,12 +115,12 @@ public class GameCollectService {
         return new CollectResponse(decade, newlyCollected, total);
     }
 
-    private List<SpotifySearchResponse.Item> searchSpotify(String yearRange, String accessToken, int offset) {
+    private List<SpotifySearchResponse.Item> searchSpotifyByArtist(String artist, String yearRange, String accessToken) {
         try {
             SpotifySearchResponse response = spotifyWebClient
                     .get()
-                    .uri("/search?q={q}&type=track&limit={limit}&offset={offset}&market=KR",
-                            "year:" + yearRange + " genre:k-pop", SEARCH_LIMIT, offset)
+                    .uri("/search?q={q}&type=track&limit={limit}&market=KR",
+                            "artist:" + artist + " year:" + yearRange, SEARCH_LIMIT)
                     .header("Authorization", "Bearer " + accessToken)
                     .retrieve()
                     .bodyToMono(SpotifySearchResponse.class)
@@ -108,12 +129,9 @@ public class GameCollectService {
             if (response == null || response.getTracks() == null || response.getTracks().getItems() == null) {
                 return List.of();
             }
-            // popularity 필터 없이 원본 그대로 반환 (필터는 루프에서 처리)
-            List<SpotifySearchResponse.Item> items = response.getTracks().getItems();
-            log.info("[Collect] Spotify 검색 - offset={}, 결과={}곡", offset, items.size());
-            return items;
+            return response.getTracks().getItems();
         } catch (Exception e) {
-            log.warn("[Collect] Spotify 검색 실패 - offset={}, error={}", offset, e.getMessage());
+            log.warn("[Collect] Spotify 검색 실패 - artist={}, error={}", artist, e.getMessage());
             return List.of();
         }
     }

--- a/src/main/java/com/example/playlist/game/service/GameService.java
+++ b/src/main/java/com/example/playlist/game/service/GameService.java
@@ -1,25 +1,103 @@
 package com.example.playlist.game.service;
 
+import com.example.playlist.game.dto.DeezerSearchResponse;
 import com.example.playlist.game.dto.QuizTrackResponse;
-import com.example.playlist.game.entity.QuizTrack;
-import com.example.playlist.game.repository.QuizTrackMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.genai.Client;
+import com.google.genai.types.GenerateContentConfig;
+import com.google.genai.types.GenerateContentResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class GameService {
 
-    private final QuizTrackMapper quizTrackMapper;
+    private final Client geminiClient;
+    private final GenerateContentConfig geminiConfig;
+    private final WebClient deezerWebClient;
+    private final ObjectMapper objectMapper;
+
+    private static final int MAX_RETRY = 3;
 
     public QuizTrackResponse getQuizTrack(int decade) {
-        QuizTrack track = quizTrackMapper.findRandomByDecade(decade);
-        if (track == null) {
-            throw new IllegalStateException("해당 연대의 트랙이 없습니다. 관리자 페이지에서 곡을 수집해주세요.");
+        String decadeLabel = toDecadeLabel(decade);
+
+        for (int attempt = 1; attempt <= MAX_RETRY; attempt++) {
+            try {
+                // 1. Gemini에서 한국 노래 추천
+                SongInfo song = recommendFromGemini(decadeLabel, attempt);
+                log.info("[Game] Gemini 추천 - title={}, artist={}", song.title, song.artist);
+
+                // 2. Deezer에서 preview URL 조회
+                DeezerSearchResponse deezerRes = deezerWebClient
+                        .get()
+                        .uri("/search?q={q}&limit=1", song.artist + " " + song.title)
+                        .retrieve()
+                        .bodyToMono(DeezerSearchResponse.class)
+                        .block();
+
+                if (deezerRes == null || deezerRes.getData() == null || deezerRes.getData().isEmpty()) {
+                    log.warn("[Game] Deezer 결과 없음 - attempt={}, title={}", attempt, song.title);
+                    continue;
+                }
+
+                DeezerSearchResponse.DeezerTrack track = deezerRes.getData().get(0);
+                String previewUrl = track.getPreview();
+
+                if (previewUrl == null || previewUrl.isBlank()) {
+                    log.warn("[Game] Deezer preview 없음 - attempt={}, title={}", attempt, song.title);
+                    continue;
+                }
+
+                log.info("[Game] 최종 선택 - title={}, artist={}", song.title, song.artist);
+                return QuizTrackResponse.fromGemini(song.title, song.artist, previewUrl, track.getAlbumImageUrl());
+
+            } catch (Exception e) {
+                log.warn("[Game] 시도 실패 - attempt={}, error={}", attempt, e.getMessage());
+            }
         }
-        log.info("[Game] 퀴즈 트랙 반환 - decade={}, title={}, artist={}", decade, track.getTitle(), track.getArtist());
-        return QuizTrackResponse.fromEntity(track);
+
+        throw new IllegalStateException("퀴즈 트랙을 가져오는 데 실패했습니다. 잠시 후 다시 시도해주세요.");
     }
+
+    private SongInfo recommendFromGemini(String decadeLabel, int attempt) throws Exception {
+        String prompt = String.format("""
+                %s 한국 가요/K-pop 노래 중 랜덤으로 1곡만 추천해줘.
+                조건:
+                - 반드시 한국 가수의 한국 노래
+                - 제목과 가수명은 반드시 한국어로 작성 (예: 방탄소년단, 아이유)
+                - 영어 아티스트명도 한국어 표기로 (예: BTS → 방탄소년단)
+                - 실제 스트리밍 서비스에 존재하는 곡
+                - 매번 다른 곡 추천
+                - 아래 JSON 형식으로만 응답 (다른 텍스트 없이):
+                {"title": "곡제목", "artist": "아티스트명"}
+                """, decadeLabel);
+
+        GenerateContentResponse response = geminiClient.models.generateContent(
+                "gemini-3-flash-preview",
+                prompt,
+                geminiConfig
+        );
+
+        String json = response.text().trim()
+                .replaceAll("```json", "").replaceAll("```", "").trim();
+
+        return objectMapper.readValue(json, SongInfo.class);
+    }
+
+    private String toDecadeLabel(int decade) {
+        return switch (decade) {
+            case 1990 -> "1990년대(1990~1999년)";
+            case 2000 -> "2000년대(2000~2009년)";
+            case 2010 -> "2010년대(2010~2019년)";
+            case 2020 -> "2020년대(2020~현재)";
+            default -> throw new IllegalArgumentException("지원하지 않는 연대입니다: " + decade);
+        };
+    }
+
+    record SongInfo(String title, String artist) {}
 }


### PR DESCRIPTION
- GameService: Gemini로 한국 노래 추천 후 Deezer에서 preview URL 조회 (MAX_RETRY=3)
- DeezerSearchResponse: album.cover_big 필드 추가 (앨범 이미지)
- QuizTrackResponse: fromGemini() 팩토리 메서드 추가, titleNormalized/artistNormalized 필드 추가 (띄어쓰기 제거, 소문자 정규화)
- GameCollectService: 변수명 충돌(artist) 수정