### PR TITLE
게임 구조 전면 개편: Gemini+iTunes DB 사전수집 방식으로 전환

### DIFF
--- a/src/main/java/com/example/playlist/game/controller/GameController.java
+++ b/src/main/java/com/example/playlist/game/controller/GameController.java
@@ -18,22 +18,22 @@ public class GameController {
 
     @Operation(
             summary = "퀴즈 트랙 조회",
-            description = "연대별 랜덤 트랙 반환. decade: 1990 / 2000 / 2010 / 2020"
+            description = "연대별 랜덤 트랙 반환. decade: 1990_EARLY / 1990_LATE / 2000 / 2010 / 2020"
     )
     @GetMapping("/game/quiz")
     public ResponseEntity<QuizTrackResponse> getQuizTrack(
-            @RequestParam int decade
+            @RequestParam String decade
     ) {
         return ResponseEntity.ok(gameService.getQuizTrack(decade));
     }
 
     @Operation(
             summary = "[Admin] 퀴즈 트랙 수집",
-            description = "연대별 한국 노래 100곡을 Spotify + Deezer에서 수집해 DB에 저장. decade: 1990 / 2000 / 2010 / 2020"
+            description = "Gemini 추천 + iTunes preview 검증 후 DB 저장 (50곡, 중복 제외). decade: 1990_EARLY / 1990_LATE / 2000 / 2010 / 2020"
     )
     @PostMapping("/admin/game/collect")
     public ResponseEntity<CollectResponse> collectTracks(
-            @RequestParam int decade
+            @RequestParam String decade
     ) {
         return ResponseEntity.ok(gameCollectService.collectTracks(decade));
     }

--- a/src/main/java/com/example/playlist/game/dto/CollectResponse.java
+++ b/src/main/java/com/example/playlist/game/dto/CollectResponse.java
@@ -1,7 +1,7 @@
 package com.example.playlist.game.dto;
 
 public record CollectResponse(
-        int decade,
+        String decade,
         int newlyCollected,
         int totalInDb
 ) {}

--- a/src/main/java/com/example/playlist/game/dto/ItunesSearchResponse.java
+++ b/src/main/java/com/example/playlist/game/dto/ItunesSearchResponse.java
@@ -1,0 +1,26 @@
+package com.example.playlist.game.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class ItunesSearchResponse {
+
+    private int resultCount;
+    private List<ItunesTrack> results;
+
+    @Getter
+    public static class ItunesTrack {
+        private Long trackId;
+        private String trackName;
+        private String artistName;
+        private String previewUrl;
+        private String artworkUrl100;
+
+        public String getArtworkUrl() {
+            if (artworkUrl100 == null) return null;
+            return artworkUrl100.replace("100x100bb", "500x500bb");
+        }
+    }
+}

--- a/src/main/java/com/example/playlist/game/dto/QuizTrackResponse.java
+++ b/src/main/java/com/example/playlist/game/dto/QuizTrackResponse.java
@@ -1,9 +1,6 @@
 package com.example.playlist.game.dto;
 
 import com.example.playlist.game.entity.QuizTrack;
-import com.example.playlist.spotify.dto.SpotifySearchResponse;
-
-import java.util.List;
 
 public record QuizTrackResponse(
         String trackId,
@@ -16,47 +13,13 @@ public record QuizTrackResponse(
 ) {
     public static QuizTrackResponse fromEntity(QuizTrack track) {
         return new QuizTrackResponse(
-                track.getSpotifyTrackId(),
+                track.getItunesTrackId(),
                 track.getPreviewUrl(),
                 track.getTitle(),
                 track.getArtist(),
                 track.getAlbumImageUrl(),
                 normalize(track.getTitle()),
                 normalize(track.getArtist())
-        );
-    }
-
-    public static QuizTrackResponse from(SpotifySearchResponse.Item item, String previewUrl) {
-        String artist = item.getArtists() != null && !item.getArtists().isEmpty()
-                ? item.getArtists().get(0).getName()
-                : "Unknown";
-
-        String imageUrl = null;
-        List<SpotifySearchResponse.AlbumImage> images = item.getAlbum().getImages();
-        if (images != null && !images.isEmpty()) {
-            imageUrl = images.get(0).getUrl();
-        }
-
-        return new QuizTrackResponse(
-                item.getTrackId(),
-                previewUrl,
-                item.getName(),
-                artist,
-                imageUrl,
-                normalize(item.getName()),
-                normalize(artist)
-        );
-    }
-
-    public static QuizTrackResponse fromGemini(String title, String artist, String previewUrl, String albumImageUrl) {
-        return new QuizTrackResponse(
-                null,
-                previewUrl,
-                title,
-                artist,
-                albumImageUrl,
-                normalize(title),
-                normalize(artist)
         );
     }
 

--- a/src/main/java/com/example/playlist/game/entity/QuizTrack.java
+++ b/src/main/java/com/example/playlist/game/entity/QuizTrack.java
@@ -13,7 +13,7 @@ public class QuizTrack {
     private String artist;
     private String albumImageUrl;
     private String previewUrl;
-    private int decade;
-    private String spotifyTrackId;
+    private String decade;
+    private String itunesTrackId;
     private LocalDateTime createdAt;
 }

--- a/src/main/java/com/example/playlist/game/repository/QuizTrackMapper.java
+++ b/src/main/java/com/example/playlist/game/repository/QuizTrackMapper.java
@@ -4,10 +4,13 @@ import com.example.playlist.game.entity.QuizTrack;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
+import java.util.List;
+
 @Mapper
 public interface QuizTrackMapper {
     void insert(QuizTrack track);
-    boolean existsBySpotifyTrackId(@Param("spotifyTrackId") String spotifyTrackId);
-    QuizTrack findRandomByDecade(@Param("decade") int decade);
-    int countByDecade(@Param("decade") int decade);
+    boolean existsByItunesTrackId(@Param("itunesTrackId") String itunesTrackId);
+    List<String> findTitlesByDecade(@Param("decade") String decade);
+    QuizTrack findRandomByDecade(@Param("decade") String decade);
+    int countByDecade(@Param("decade") String decade);
 }

--- a/src/main/java/com/example/playlist/game/service/GameCollectService.java
+++ b/src/main/java/com/example/playlist/game/service/GameCollectService.java
@@ -1,168 +1,163 @@
 package com.example.playlist.game.service;
 
 import com.example.playlist.game.dto.CollectResponse;
-import com.example.playlist.game.dto.DeezerSearchResponse;
+import com.example.playlist.game.dto.ItunesSearchResponse;
 import com.example.playlist.game.entity.QuizTrack;
 import com.example.playlist.game.repository.QuizTrackMapper;
-import com.example.playlist.spotify.dto.SpotifySearchResponse;
-import com.example.playlist.spotify.service.SpotifyTokenService;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.genai.Client;
+import com.google.genai.types.GenerateContentConfig;
+import com.google.genai.types.GenerateContentResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class GameCollectService {
 
-    private final SpotifyTokenService spotifyTokenService;
-    private final WebClient spotifyWebClient;
-    private final WebClient deezerWebClient;
+    private final Client geminiClient;
+    private final GenerateContentConfig geminiConfig;
+    private final WebClient itunesWebClient;
     private final QuizTrackMapper quizTrackMapper;
+    private final ObjectMapper objectMapper;
 
-    private static final int SEARCH_LIMIT = 10;
-    private static final int TARGET = 100;
+    private static final int TARGET = 50;
+    private static final int BATCH_SIZE = 15;
+    private static final int MAX_GEMINI_CALLS = 10;
 
-    private static final Map<Integer, List<String>> KOREAN_ARTISTS = Map.of(
-        1990, List.of(
-            "서태지와 아이들", "김건모", "신승훈", "H.O.T.", "S.E.S.",
-            "god", "Fin.K.L", "젝스키스", "이승환", "조성모", "클론",
-            "박진영", "유승준", "룰라", "015B", "김광석", "이적",
-            "노이즈", "솔리드", "듀스", "DJ DOC", "토이", "패닉"
-        ),
-        2000, List.of(
-            "TVXQ", "Big Bang", "Wonder Girls", "Girls Generation", "2NE1",
-            "Super Junior", "KARA", "2PM", "SHINee", "BoA", "SS501",
-            "이효리", "비", "버즈", "브라운아이드걸스", "에픽하이",
-            "원더걸스", "f(x)", "씨스타", "4Minute", "지드래곤", "태양"
-        ),
-        2010, List.of(
-            "BTS", "EXO", "TWICE", "BLACKPINK", "Red Velvet",
-            "IU", "PSY", "INFINITE", "SISTAR", "GOT7", "Wanna One",
-            "NCT 127", "MAMAMOO", "AOA", "B2ST", "2AM", "케이윌",
-            "악동뮤지션", "볼빨간사춘기", "선미", "CL", "지코"
-        ),
-        2020, List.of(
-            "BTS", "BLACKPINK", "aespa", "IVE", "NewJeans",
-            "Stray Kids", "ITZY", "SEVENTEEN", "LE SSERAFIM", "NCT 127",
-            "ENHYPEN", "G I-DLE", "TXT", "ATEEZ", "Kep1er",
-            "NMIXX", "fromis 9", "BTOB", "임영웅", "이찬원"
-        )
-    );
-
-    public CollectResponse collectTracks(int decade) {
-        String yearRange = toYearRange(decade);
-        String accessToken = spotifyTokenService.getAccessToken();
-
-        List<String> artists = KOREAN_ARTISTS.get(decade);
+    public CollectResponse collectTracks(String decade) {
+        String decadeLabel = toDecadeLabel(decade);
         int newlyCollected = 0;
 
-        for (String artist : artists) {
-            if (newlyCollected >= TARGET) break;
+        // DB에 이미 있는 제목을 Gemini 제외 목록으로 활용
+        List<String> seenTitles = new ArrayList<>(quizTrackMapper.findTitlesByDecade(decade));
+        log.info("[Collect] 시작 - decade={}, 기존 DB={}곡", decade, seenTitles.size());
 
-            List<SpotifySearchResponse.Item> items = searchSpotifyByArtist(artist, yearRange, accessToken);
-            log.info("[Collect] 아티스트={}, 결과={}곡", artist, items.size());
+        for (int attempt = 0; attempt < MAX_GEMINI_CALLS && newlyCollected < TARGET; attempt++) {
+            try {
+                List<SongRecommendation> songs = recommendBatchFromGemini(decadeLabel, seenTitles);
+                log.info("[Collect] Gemini 추천 {}곡 - attempt={}", songs.size(), attempt + 1);
 
-            for (SpotifySearchResponse.Item item : items) {
-                if (newlyCollected >= TARGET) break;
+                for (SongRecommendation song : songs) {
+                    if (newlyCollected >= TARGET) break;
+                    seenTitles.add(song.title());
 
-                // 이미 DB에 있으면 스킵
-                if (quizTrackMapper.existsBySpotifyTrackId(item.getTrackId())) {
-                    log.debug("[Collect] 중복 스킵 - title={}", item.getName());
-                    continue;
+                    ItunesSearchResponse.ItunesTrack track = findOnItunes(song.searchQuery());
+                    if (track == null || track.getPreviewUrl() == null || track.getPreviewUrl().isBlank()) {
+                        log.debug("[Collect] iTunes preview 없음 - title={}", song.title());
+                        continue;
+                    }
+
+                    String itunesTrackId = String.valueOf(track.getTrackId());
+                    if (quizTrackMapper.existsByItunesTrackId(itunesTrackId)) {
+                        log.debug("[Collect] 중복 스킵 - title={}", song.title());
+                        continue;
+                    }
+
+                    quizTrackMapper.insert(QuizTrack.builder()
+                            .title(song.title())
+                            .artist(song.artist())
+                            .albumImageUrl(track.getArtworkUrl())
+                            .previewUrl(track.getPreviewUrl())
+                            .decade(decade)
+                            .itunesTrackId(itunesTrackId)
+                            .build());
+
+                    newlyCollected++;
+                    log.info("[Collect] 저장 [{}/{}] title={}, artist={}", newlyCollected, TARGET, song.title(), song.artist());
                 }
 
-                String trackArtist = item.getArtists() != null && !item.getArtists().isEmpty()
-                        ? item.getArtists().get(0).getName() : "";
+                // iTunes rate limit 방지
+                Thread.sleep(300);
 
-                // Deezer preview 확인
-                String previewUrl = getDeezerPreview(item.getName(), trackArtist);
-                if (previewUrl == null) {
-                    log.debug("[Collect] Deezer preview 없음 - title={}", item.getName());
-                    continue;
-                }
-
-                String albumImageUrl = null;
-                if (item.getAlbum() != null && item.getAlbum().getImages() != null
-                        && !item.getAlbum().getImages().isEmpty()) {
-                    albumImageUrl = item.getAlbum().getImages().get(0).getUrl();
-                }
-
-                quizTrackMapper.insert(QuizTrack.builder()
-                        .title(item.getName())
-                        .artist(trackArtist)
-                        .albumImageUrl(albumImageUrl)
-                        .previewUrl(previewUrl)
-                        .decade(decade)
-                        .spotifyTrackId(item.getTrackId())
-                        .build());
-
-                newlyCollected++;
-                log.info("[Collect] 저장 - [{}/{}] title={}, artist={}, popularity={}",
-                        newlyCollected, TARGET, item.getName(), trackArtist, item.getPopularity());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            } catch (Exception e) {
+                log.warn("[Collect] Gemini 추천 실패 - attempt={}, error={}", attempt + 1, e.getMessage());
             }
-
-            // Spotify rate limit 방지 딜레이
-            try { Thread.sleep(200); } catch (InterruptedException ignored) {}
         }
 
         int total = quizTrackMapper.countByDecade(decade);
-        log.info("[Collect] 완료 - decade={}, 신규={}, DB총={}", decade, newlyCollected, total);
+        log.info("[Collect] 완료 - decade={}, 신규={}곡, DB총={}곡", decade, newlyCollected, total);
         return new CollectResponse(decade, newlyCollected, total);
     }
 
-    private List<SpotifySearchResponse.Item> searchSpotifyByArtist(String artist, String yearRange, String accessToken) {
-        try {
-            SpotifySearchResponse response = spotifyWebClient
-                    .get()
-                    .uri("/search?q={q}&type=track&limit={limit}&market=KR",
-                            "artist:" + artist + " year:" + yearRange, SEARCH_LIMIT)
-                    .header("Authorization", "Bearer " + accessToken)
-                    .retrieve()
-                    .bodyToMono(SpotifySearchResponse.class)
-                    .block();
+    private List<SongRecommendation> recommendBatchFromGemini(String decadeLabel, List<String> excludeTitles) throws Exception {
+        String exclusionList = excludeTitles.isEmpty() ? "없음" : String.join(", ", excludeTitles);
 
-            if (response == null || response.getTracks() == null || response.getTracks().getItems() == null) {
-                return List.of();
-            }
-            return response.getTracks().getItems();
-        } catch (Exception e) {
-            log.warn("[Collect] Spotify 검색 실패 - artist={}, error={}", artist, e.getMessage());
-            return List.of();
+        String prompt = String.format("""
+                %s 한국 가요/K-pop 중 유명한 노래 %d곡을 추천해줘.
+                조건:
+                - 사람들이 노래만 듣고 제목을 맞출 수 있는 유명한 곡
+                - 원곡만 (일본어 버전, MR버전, 리믹스, 라이브 버전 절대 제외)
+                - Apple Music/iTunes에서 검색 가능한 곡
+                - 아래 제목은 반드시 제외: %s
+                - JSON 배열로만 응답 (다른 텍스트 없이):
+                [{"title": "한국어제목", "artist": "한국어아티스트명", "searchQuery": "English artist and song title for iTunes search"}]
+                """, decadeLabel, BATCH_SIZE, exclusionList);
+
+        GenerateContentResponse response = geminiClient.models.generateContent(
+                "gemini-2.0-flash", prompt, geminiConfig);
+
+        String json = response.text().trim()
+                .replaceAll("```json", "").replaceAll("```", "").trim();
+
+        log.debug("[Collect] Gemini raw={}", json);
+
+        JsonNode node = objectMapper.readTree(json);
+        if (!node.isArray() && node.has("songs")) {
+            node = node.get("songs");
         }
+
+        List<SongRecommendation> result = new ArrayList<>();
+        for (JsonNode item : node) {
+            String title = item.path("title").asText(null);
+            String artist = item.path("artist").asText(null);
+            String searchQuery = item.path("searchQuery").asText(null);
+            if (title == null || artist == null) continue;
+            if (searchQuery == null) searchQuery = artist + " " + title;
+            result.add(new SongRecommendation(title, artist, searchQuery));
+        }
+        return result;
     }
 
-    private String getDeezerPreview(String title, String artist) {
+    private ItunesSearchResponse.ItunesTrack findOnItunes(String searchQuery) {
         try {
-            DeezerSearchResponse response = deezerWebClient
+            ItunesSearchResponse response = itunesWebClient
                     .get()
-                    .uri("/search?q={q}&limit=1", artist + " " + title)
+                    .uri("/search?term={term}&country=KR&media=music&entity=song&limit=1", searchQuery)
                     .retrieve()
-                    .bodyToMono(DeezerSearchResponse.class)
+                    .bodyToMono(ItunesSearchResponse.class)
                     .block();
 
-            if (response == null || response.getData() == null || response.getData().isEmpty()) {
+            if (response == null || response.getResultCount() == 0 || response.getResults().isEmpty()) {
                 return null;
             }
-            String preview = response.getData().get(0).getPreview();
-            return (preview != null && !preview.isBlank()) ? preview : null;
+            return response.getResults().get(0);
         } catch (Exception e) {
-            log.warn("[Collect] Deezer 조회 실패 - title={}, error={}", title, e.getMessage());
+            log.warn("[Collect] iTunes 조회 실패 - query={}, error={}", searchQuery, e.getMessage());
             return null;
         }
     }
 
-    private String toYearRange(int decade) {
+    private String toDecadeLabel(String decade) {
         return switch (decade) {
-            case 1990 -> "1990-1999";
-            case 2000 -> "2000-2009";
-            case 2010 -> "2010-2019";
-            case 2020 -> "2020-2029";
-            default -> throw new IllegalArgumentException("지원하지 않는 연대입니다: " + decade);
+            case "1990_EARLY" -> "1990년대 초반(1990~1994년)";
+            case "1990_LATE"  -> "1990년대 후반(1995~1999년)";
+            case "2000"       -> "2000년대(2000~2009년)";
+            case "2010"       -> "2010년대(2010~2019년)";
+            case "2020"       -> "2020년대(2020~현재)";
+            default -> throw new IllegalArgumentException("지원하지 않는 연대: " + decade);
         };
     }
+
+    record SongRecommendation(String title, String artist, String searchQuery) {}
 }

--- a/src/main/java/com/example/playlist/game/service/GameService.java
+++ b/src/main/java/com/example/playlist/game/service/GameService.java
@@ -1,115 +1,25 @@
 package com.example.playlist.game.service;
 
-import com.example.playlist.game.dto.DeezerSearchResponse;
 import com.example.playlist.game.dto.QuizTrackResponse;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.genai.Client;
-import com.google.genai.types.GenerateContentConfig;
-import com.google.genai.types.GenerateContentResponse;
+import com.example.playlist.game.entity.QuizTrack;
+import com.example.playlist.game.repository.QuizTrackMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.web.reactive.function.client.WebClient;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class GameService {
 
-    private final Client geminiClient;
-    private final GenerateContentConfig geminiConfig;
-    private final WebClient deezerWebClient;
-    private final ObjectMapper objectMapper;
+    private final QuizTrackMapper quizTrackMapper;
 
-    private static final int MAX_RETRY = 3;
-
-    public QuizTrackResponse getQuizTrack(int decade) {
-        String decadeLabel = toDecadeLabel(decade);
-
-        for (int attempt = 1; attempt <= MAX_RETRY; attempt++) {
-            try {
-                // 1. Gemini에서 한국 노래 추천
-                SongInfo song = recommendFromGemini(decadeLabel, attempt);
-                log.info("[Game] Gemini 추천 - title={}, artist={}", song.title, song.artist);
-
-                // 2. Deezer에서 preview URL 조회 (영어 검색어 사용)
-                DeezerSearchResponse deezerRes = deezerWebClient
-                        .get()
-                        .uri("/search?q={q}&limit=1", song.searchQuery)
-                        .retrieve()
-                        .bodyToMono(DeezerSearchResponse.class)
-                        .block();
-
-                if (deezerRes == null || deezerRes.getData() == null || deezerRes.getData().isEmpty()) {
-                    log.warn("[Game] Deezer 결과 없음 - attempt={}, title={}", attempt, song.title);
-                    continue;
-                }
-
-                DeezerSearchResponse.DeezerTrack track = deezerRes.getData().get(0);
-                String previewUrl = track.getPreview();
-
-                if (previewUrl == null || previewUrl.isBlank()) {
-                    log.warn("[Game] Deezer preview 없음 - attempt={}, title={}", attempt, song.title);
-                    continue;
-                }
-
-                log.info("[Game] 최종 선택 - title={}, artist={}", song.title, song.artist);
-                return QuizTrackResponse.fromGemini(song.title, song.artist, previewUrl, track.getAlbumImageUrl());
-
-            } catch (Exception e) {
-                log.warn("[Game] 시도 실패 - attempt={}, error={}", attempt, e.getMessage());
-            }
+    public QuizTrackResponse getQuizTrack(String decade) {
+        QuizTrack track = quizTrackMapper.findRandomByDecade(decade);
+        if (track == null) {
+            throw new IllegalStateException("해당 연대의 곡이 없습니다. 먼저 수집을 진행해주세요.");
         }
-
-        throw new IllegalStateException("퀴즈 트랙을 가져오는 데 실패했습니다. 잠시 후 다시 시도해주세요.");
+        log.info("[Game] DB 조회 - title={}, artist={}", track.getTitle(), track.getArtist());
+        return QuizTrackResponse.fromEntity(track);
     }
-
-    private SongInfo recommendFromGemini(String decadeLabel, int attempt) throws Exception {
-        String prompt = String.format("""
-                %s 한국 가요/K-pop 노래 중 랜덤으로 1곡만 추천해줘.
-                조건:
-                - 반드시 한국 가수의 한국 노래
-                - title과 artist는 한국어로 (예: 방탄소년단, 아이유)
-                - searchQuery는 Deezer 검색용 영어 표기 (예: "BTS Dynamite", "IU Celebrity")
-                - 실제 스트리밍 서비스에 존재하는 곡
-                - 매번 다른 곡 추천
-                - 아래 JSON 형식으로만 응답 (다른 텍스트 없이):
-                {"title": "곡제목(한국어)", "artist": "아티스트명(한국어)", "searchQuery": "영어 검색어"}
-                """, decadeLabel);
-
-        GenerateContentResponse response = geminiClient.models.generateContent(
-                "gemini-3-flash-preview",
-                prompt,
-                geminiConfig
-        );
-
-        String json = response.text().trim()
-                .replaceAll("```json", "").replaceAll("```", "").trim();
-
-        log.info("[Game] Gemini raw json={}", json);
-
-        com.fasterxml.jackson.databind.JsonNode node = objectMapper.readTree(json);
-
-        // Gemini가 {"songs": [...]} 형태로 반환하는 경우 처리
-        if (node.has("songs") && node.get("songs").isArray() && !node.get("songs").isEmpty()) {
-            node = node.get("songs").get(0);
-        }
-
-        String title = node.get("title").asText();
-        String artist = node.get("artist").asText();
-        String searchQuery = node.has("searchQuery") ? node.get("searchQuery").asText() : artist + " " + title;
-        return new SongInfo(title, artist, searchQuery);
-    }
-
-    private String toDecadeLabel(int decade) {
-        return switch (decade) {
-            case 1990 -> "1990년대(1990~1999년)";
-            case 2000 -> "2000년대(2000~2009년)";
-            case 2010 -> "2010년대(2010~2019년)";
-            case 2020 -> "2020년대(2020~현재)";
-            default -> throw new IllegalArgumentException("지원하지 않는 연대입니다: " + decade);
-        };
-    }
-
-    record SongInfo(String title, String artist, String searchQuery) {}
 }

--- a/src/main/java/com/example/playlist/global/config/WebClientConfig.java
+++ b/src/main/java/com/example/playlist/global/config/WebClientConfig.java
@@ -28,4 +28,11 @@ public class WebClientConfig {
                 .build();
     }
 
+    @Bean
+    public WebClient itunesWebClient() {
+        return WebClient.builder()
+                .baseUrl("https://itunes.apple.com")
+                .build();
+    }
+
 }

--- a/src/main/resources/mapper/QuizTrackMapper.xml
+++ b/src/main/resources/mapper/QuizTrackMapper.xml
@@ -5,18 +5,24 @@
 <mapper namespace="com.example.playlist.game.repository.QuizTrackMapper">
 
     <insert id="insert" useGeneratedKeys="true" keyProperty="id">
-        INSERT INTO quiz_track (title, artist, album_image_url, preview_url, decade, spotify_track_id)
-        VALUES (#{title}, #{artist}, #{albumImageUrl}, #{previewUrl}, #{decade}, #{spotifyTrackId})
+        INSERT INTO quiz_track (title, artist, album_image_url, preview_url, decade, itunes_track_id)
+        VALUES (#{title}, #{artist}, #{albumImageUrl}, #{previewUrl}, #{decade}, #{itunesTrackId})
     </insert>
 
-    <select id="existsBySpotifyTrackId" resultType="boolean">
+    <select id="existsByItunesTrackId" resultType="boolean">
         SELECT COUNT(*) > 0
         FROM quiz_track
-        WHERE spotify_track_id = #{spotifyTrackId}
+        WHERE itunes_track_id = #{itunesTrackId}
+    </select>
+
+    <select id="findTitlesByDecade" resultType="string">
+        SELECT title
+        FROM quiz_track
+        WHERE decade = #{decade}
     </select>
 
     <select id="findRandomByDecade" resultType="com.example.playlist.game.entity.QuizTrack">
-        SELECT id, title, artist, album_image_url, preview_url, decade, spotify_track_id, created_at
+        SELECT id, title, artist, album_image_url, preview_url, decade, itunes_track_id, created_at
         FROM quiz_track
         WHERE decade = #{decade}
         ORDER BY RANDOM()


### PR DESCRIPTION
- 카테고리 5개: 1990_EARLY / 1990_LATE / 2000 / 2010 / 2020
- GameCollectService: Gemini 배치 추천(15곡) → iTunes preview 검증 → DB 저장(50곡/회)
  - 원곡 조건 강화 (일본어/MR/리믹스 제외), 기존 DB 곡 Gemini 제외 목록으로 전달
- GameService: DB에서 랜덤 조회로 단순화
- ItunesSearchResponse DTO 추가
- QuizTrack: decade String, spotifyTrackId → itunesTrackId
- QuizTrackMapper: findTitlesByDecade, String decade 파라미터
- DB 컬럼 변경에 맞게 XML 쿼리 업데이트