### PR TITLE
수집 비동기 처리로 504 타임아웃 해결 + Gemini searchQuery 강제화

### DIFF
--- a/src/main/java/com/example/playlist/game/controller/GameController.java
+++ b/src/main/java/com/example/playlist/game/controller/GameController.java
@@ -1,6 +1,5 @@
 package com.example.playlist.game.controller;
 
-import com.example.playlist.game.dto.CollectResponse;
 import com.example.playlist.game.dto.QuizTrackResponse;
 import com.example.playlist.game.service.GameCollectService;
 import com.example.playlist.game.service.GameService;
@@ -8,6 +7,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -28,13 +29,29 @@ public class GameController {
     }
 
     @Operation(
-            summary = "[Admin] 퀴즈 트랙 수집",
-            description = "Gemini 추천 + iTunes preview 검증 후 DB 저장 (50곡, 중복 제외). decade: 1990_EARLY / 1990_LATE / 2000 / 2010 / 2020"
+            summary = "[Admin] 퀴즈 트랙 수집 (비동기)",
+            description = "백그라운드에서 Gemini 추천 + iTunes preview 검증 후 DB 저장 (50곡, 중복 제외). decade: 1990_EARLY / 1990_LATE / 2000 / 2010 / 2020"
     )
     @PostMapping("/admin/game/collect")
-    public ResponseEntity<CollectResponse> collectTracks(
+    public ResponseEntity<Map<String, String>> collectTracks(
             @RequestParam String decade
     ) {
-        return ResponseEntity.ok(gameCollectService.collectTracks(decade));
+        gameCollectService.collectTracksAsync(decade);
+        return ResponseEntity.accepted().body(Map.of(
+                "message", "수집이 백그라운드에서 시작되었습니다. 서버 로그를 확인하세요.",
+                "decade", decade
+        ));
+    }
+
+    @Operation(
+            summary = "[Admin] 연대별 퀴즈 트랙 수 조회",
+            description = "decade: 1990_EARLY / 1990_LATE / 2000 / 2010 / 2020"
+    )
+    @GetMapping("/admin/game/count")
+    public ResponseEntity<Map<String, Object>> countTracks(
+            @RequestParam String decade
+    ) {
+        int count = gameCollectService.countByDecade(decade);
+        return ResponseEntity.ok(Map.of("decade", decade, "count", count));
     }
 }

--- a/src/main/java/com/example/playlist/game/service/GameCollectService.java
+++ b/src/main/java/com/example/playlist/game/service/GameCollectService.java
@@ -16,6 +16,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 @Slf4j
 @Service
@@ -31,6 +32,14 @@ public class GameCollectService {
     private static final int TARGET = 50;
     private static final int BATCH_SIZE = 15;
     private static final int MAX_GEMINI_CALLS = 10;
+
+    public void collectTracksAsync(String decade) {
+        CompletableFuture.runAsync(() -> collectTracks(decade));
+    }
+
+    public int countByDecade(String decade) {
+        return quizTrackMapper.countByDecade(decade);
+    }
 
     public CollectResponse collectTracks(String decade) {
         String decadeLabel = toDecadeLabel(decade);
@@ -104,8 +113,12 @@ public class GameCollectService {
                 - 원곡만 (일본어 버전, MR버전, 리믹스, 라이브 버전 절대 제외)
                 - Apple Music/iTunes에서 검색 가능한 곡
                 - 아래 제목은 반드시 제외: %s
-                - JSON 배열로만 응답 (다른 텍스트 없이):
-                [{"title": "한국어제목", "artist": "한국어아티스트명", "searchQuery": "English artist and song title for iTunes search"}]
+                - 아래 JSON 배열 형식으로만 응답 (설명 없이, 코드블록 없이):
+                [
+                  {"title": "한국어제목", "artist": "한국어아티스트명", "searchQuery": "IU Celebrity"},
+                  {"title": "한국어제목2", "artist": "한국어아티스트명2", "searchQuery": "BTS Dynamite"}
+                ]
+                searchQuery는 반드시 영어로 작성 (아티스트 영어명 + 곡 제목). 예: "IU Celebrity", "BTS Butter", "NewJeans Hype Boy", "BLACKPINK How You Like That"
                 """, decadeLabel, BATCH_SIZE, exclusionList);
 
         GenerateContentResponse response = geminiClient.models.generateContent(


### PR DESCRIPTION
- 수집 API: 즉시 202 반환, 백그라운드에서 처리
- GET /admin/game/count?decade= 엔드포인트 추가 (수집 완료 확인용)
- Gemini 프롬프트에 searchQuery 영어 예시 명시