### PR TITLE
feat: 퀴즈 게임 개편 + AI 플레이리스트 개선

### DIFF
--- a/src/main/java/com/example/playlist/game/service/GameCollectService.java
+++ b/src/main/java/com/example/playlist/game/service/GameCollectService.java
@@ -138,7 +138,7 @@ public class GameCollectService {
                 """, decadeLabel, BATCH_SIZE, exclusionList);
 
         GenerateContentResponse response = geminiClient.models.generateContent(
-                "gemini-2.0-flash", prompt, geminiConfig);
+                "gemini-3-flash-preview", prompt, geminiConfig);
 
         String json = response.text().trim()
                 .replaceAll("```json", "").replaceAll("```", "").trim();

--- a/src/main/java/com/example/playlist/gemini/controller/GeminiController.java
+++ b/src/main/java/com/example/playlist/gemini/controller/GeminiController.java
@@ -6,6 +6,7 @@ import com.example.playlist.gemini.dto.GeminiRequest;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -25,7 +26,7 @@ public class GeminiController {
     )
     @PostMapping("/playlist")
     public GeminiResponse createPlaylist(
-            @RequestBody GeminiRequest request,
+            @Valid @RequestBody GeminiRequest request,
             HttpServletRequest httpRequest
     ) throws JsonProcessingException {
         String clientIp = getClientIp(httpRequest);

--- a/src/main/java/com/example/playlist/gemini/dto/GeminiRequest.java
+++ b/src/main/java/com/example/playlist/gemini/dto/GeminiRequest.java
@@ -1,5 +1,7 @@
 package com.example.playlist.gemini.dto;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -8,6 +10,9 @@ import lombok.Setter;
 public class GeminiRequest {
     private String prompt;
     private String category;
+
+    @Min(1)
+    @Max(30)
     private int songCount = 10;
 
     public String toPrompt() {

--- a/src/main/java/com/example/playlist/gemini/service/GeminiService.java
+++ b/src/main/java/com/example/playlist/gemini/service/GeminiService.java
@@ -30,7 +30,7 @@ public class GeminiService {
         try {
             GenerateContentResponse response =
                     geminiClient.models.generateContent(
-                            "gemini-2.0-flash",
+                            "gemini-3-flash-preview",
                             request.toPrompt(),
                             geminiConfig
                     );

--- a/src/main/java/com/example/playlist/playlist/controller/PlaylistController.java
+++ b/src/main/java/com/example/playlist/playlist/controller/PlaylistController.java
@@ -30,7 +30,7 @@ public class PlaylistController {
     @Operation(summary = "AI 플레이리스트 추천", description = "Gemini가 추천한 곡들을 Spotify에서 검색해서 반환 (DB 미저장)")
     @PostMapping
     public PlaylistResponse createPlaylist(
-            @RequestBody GeminiRequest geminiRequest,
+            @Valid @RequestBody GeminiRequest geminiRequest,
             HttpServletRequest httpRequest
     ) throws JsonProcessingException {
         String clientIp = getClientIp(httpRequest);


### PR DESCRIPTION
## Summary

### 퀴즈 게임 전면 개편
- **아키텍처 변경**: 매 요청마다 Gemini 호출 → Gemini+iTunes DB 사전수집 방식으로 전환
  - `POST /admin/game/collect?decade=` : Gemini 배치 추천(15곡) → iTunes preview 검증 → DB 저장 (50곡, 비동기)
  - `GET /admin/game/collect/status?decade=` : 수집 진행 상태 조회 (IDLE/RUNNING/COMPLETED)
  - `GET /game/quiz?decade=` : DB에서 랜덤 조회
- **연대 카테고리 5개로 세분화**: `1990_EARLY` / `1990_LATE` / `2000` / `2010` / `2020`
- **DB 변경**: `decade` INT→VARCHAR, `spotify_track_id`→`itunes_track_id`, `title_alias`/`artist_alias` 컬럼 추가
- **정답 처리 개선**
  - 괄호 안 부제 자동 제거 (`다시 만난 세계(Into the New World)` → `다시만난세계`)
  - iTunes 영어 아티스트명/제목 alias 저장 → 한국어/영어 둘 다 정답 허용
  - 대소문자 구분 없이 정답 처리

### AI 플레이리스트 개선
- **IP 기반 Rate Limiting**: IP당 분당 5회 초과 시 429 반환 (Redis TTL 60초)
- **songCount 제한**: 최대 30곡 (`@Max(30)` 유효성 검사), 미입력 시 기본 10곡
- 곡 수를 프론트에서 자유롭게 지정 가능 (request body `songCount` 필드)

### 버그 수정
- iTunes API `text/javascript` 콘텐츠 타입 파싱 오류 → `String`으로 수신 후 수동 역직렬화
- Gemini record 역직렬화 null 버그 → `JsonNode` 직접 파싱으로 수정
- Gemini `songs` 배열 응답 형식 처리
- 수집 API 504 Gateway Timeout → 비동기 처리로 해결

## DB Migration (수동 실행 필요)
```sql
ALTER TABLE quiz_track ALTER COLUMN decade TYPE VARCHAR(20) USING decade::TEXT;
ALTER TABLE quiz_track RENAME COLUMN spotify_track_id TO itunes_track_id;
ALTER TABLE quiz_track ADD COLUMN title_alias VARCHAR(500);
ALTER TABLE quiz_track ADD COLUMN artist_alias VARCHAR(200);
```

## Test plan
- [ ] `POST /admin/game/collect?decade=2020` 호출 후 202 즉시 응답 확인
- [ ] `GET /admin/game/collect/status?decade=2020` 로 진행 상태 확인
- [ ] `GET /game/quiz?decade=2020` DB 랜덤 조회 확인
- [ ] 정답 입력 시 띄어쓰기/대소문자/괄호 부제 무시 확인
- [ ] AI 플레이리스트 분당 5회 초과 시 429 반환 확인
- [ ] `songCount: 31` 요청 시 400 에러 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)