### PR TITLE
보안 취약점 수정 / 불필요 로그 정리 / 곡 수집 비용 최적화

### DIFF
--- a/src/main/java/com/example/playlist/game/controller/GameController.java
+++ b/src/main/java/com/example/playlist/game/controller/GameController.java
@@ -36,9 +36,16 @@ public class GameController {
     public ResponseEntity<Map<String, String>> collectTracks(
             @RequestParam String decade
     ) {
-        gameCollectService.collectTracksAsync(decade);
+        try {
+            gameCollectService.collectTracksAsync(decade);
+        } catch (IllegalStateException e) {
+            return ResponseEntity.status(409).body(Map.of(
+                    "message", e.getMessage(),
+                    "decade", decade
+            ));
+        }
         return ResponseEntity.accepted().body(Map.of(
-                "message", "수집이 백그라운드에서 시작되었습니다. 서버 로그를 확인하세요.",
+                "message", "수집이 백그라운드에서 시작되었습니다.",
                 "decade", decade
         ));
     }

--- a/src/main/java/com/example/playlist/game/controller/GameController.java
+++ b/src/main/java/com/example/playlist/game/controller/GameController.java
@@ -9,7 +9,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
-import com.example.playlist.game.service.GameCollectService;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/example/playlist/game/service/GameCollectService.java
+++ b/src/main/java/com/example/playlist/game/service/GameCollectService.java
@@ -39,6 +39,10 @@ public class GameCollectService {
     private final Map<String, CollectStatus> statusMap = new ConcurrentHashMap<>();
 
     public void collectTracksAsync(String decade) {
+        CollectStatus current = statusMap.get(decade);
+        if (current != null && "RUNNING".equals(current.status())) {
+            throw new IllegalStateException("이미 수집이 진행 중입니다. 완료 후 다시 시도해주세요.");
+        }
         statusMap.put(decade, new CollectStatus("RUNNING", 0, quizTrackMapper.countByDecade(decade)));
         CompletableFuture.runAsync(() -> collectTracks(decade));
     }
@@ -56,9 +60,10 @@ public class GameCollectService {
         String decadeLabel = toDecadeLabel(decade);
         int newlyCollected = 0;
 
-        // DB에 이미 있는 제목을 Gemini 제외 목록으로 활용
-        List<String> seenTitles = new ArrayList<>(quizTrackMapper.findTitlesByDecade(decade));
-        log.info("[Collect] 시작 - decade={}, 기존 DB={}곡", decade, seenTitles.size());
+        // 이번 수집 중 Gemini가 추천한 제목만 제외 목록으로 사용 (DB 전체 제목은 제외하지 않음)
+        // 실제 중복 방지는 existsByItunesTrackId 에서 처리
+        List<String> seenTitles = new ArrayList<>();
+        log.info("[Collect] 시작 - decade={}, 기존 DB={}곡", decade, quizTrackMapper.countByDecade(decade));
 
         for (int attempt = 0; attempt < MAX_GEMINI_CALLS && newlyCollected < TARGET; attempt++) {
             try {

--- a/src/main/java/com/example/playlist/game/service/GameService.java
+++ b/src/main/java/com/example/playlist/game/service/GameService.java
@@ -4,10 +4,8 @@ import com.example.playlist.game.dto.QuizTrackResponse;
 import com.example.playlist.game.entity.QuizTrack;
 import com.example.playlist.game.repository.QuizTrackMapper;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class GameService {
@@ -19,7 +17,6 @@ public class GameService {
         if (track == null) {
             throw new IllegalStateException("해당 연대의 곡이 없습니다. 먼저 수집을 진행해주세요.");
         }
-        log.info("[Game] DB 조회 - title={}, artist={}", track.getTitle(), track.getArtist());
         return QuizTrackResponse.fromEntity(track);
     }
 }

--- a/src/main/java/com/example/playlist/gemini/controller/GeminiController.java
+++ b/src/main/java/com/example/playlist/gemini/controller/GeminiController.java
@@ -34,10 +34,8 @@ public class GeminiController {
     }
 
     private String getClientIp(HttpServletRequest request) {
-        String ip = request.getHeader("X-Forwarded-For");
-        if (ip != null && !ip.isBlank()) {
-            return ip.split(",")[0].trim(); // 프록시 체인의 첫 번째 IP
-        }
+        String ip = request.getHeader("X-Real-IP");
+        if (ip != null && !ip.isBlank()) return ip;
         return request.getRemoteAddr();
     }
 }

--- a/src/main/java/com/example/playlist/global/filter/JwtFilter.java
+++ b/src/main/java/com/example/playlist/global/filter/JwtFilter.java
@@ -8,7 +8,6 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -23,7 +22,6 @@ import java.util.List;
 import java.util.Optional;
 
 @Component
-@Slf4j
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
 
@@ -62,7 +60,6 @@ public class JwtFilter extends OncePerRequestFilter {
                 jwtUtil.sendAccessAndRefreshToken(response, newAccessToken, newRefreshToken);
                 saveAuthentication(loginIdOpt.get(), role);
 
-                log.info("AccessToken 재발급");
                 filterChain.doFilter(request, response);
                 return;
             }

--- a/src/main/java/com/example/playlist/global/util/JwtUtil.java
+++ b/src/main/java/com/example/playlist/global/util/JwtUtil.java
@@ -10,7 +10,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
@@ -81,7 +80,6 @@ public class JwtUtil {
         tempCookie.setPath("/");
         tempCookie.setMaxAge(10 * 60);
         response.addCookie(tempCookie);
-        log.info("TempToken 쿠키 설정 완료");
     }
 
     public Optional<Long> extractMemberIdFromTempToken(HttpServletRequest request) {
@@ -114,8 +112,6 @@ public class JwtUtil {
         refreshCookie.setPath("/members/reissue");
         refreshCookie.setMaxAge(refreshTokenExpiration.intValue());
         response.addCookie(refreshCookie);
-
-        log.info("Access, RefreshToken 쿠키 설정 완료");
     }
 
     public Optional<String> extractAccessToken(HttpServletRequest request) {
@@ -140,7 +136,6 @@ public class JwtUtil {
                     parseClaims(token).get("loginId", String.class)
             );
         } catch (Exception e) {
-            log.info("loginId 추출 실패: {}", e.getMessage());
             return Optional.empty();
         }
     }
@@ -158,13 +153,11 @@ public class JwtUtil {
     public boolean isTokenValid(String token) {
         try {
             if (redisTemplate.opsForValue().get("BlackList:" + token) != null) {
-                log.info("로그아웃 된 토큰입니다.");
                 return false;
             }
             parseClaims(token);
             return true;
         } catch (JwtException e) {
-            log.info("유효하지 않은 Token: {}", e.getMessage());
             return false;
         }
     }
@@ -180,20 +173,16 @@ public class JwtUtil {
         }
     }
 
-    @Transactional
     public void saveRefreshToken(String loginId, String refreshToken) {
         redisTemplate.opsForValue()
                 .set("RT:" + loginId, refreshToken, Duration.ofSeconds(refreshTokenExpiration));
-        log.info("RefreshToken 저장 - loginId={}", loginId);
     }
 
-    @Transactional
     public void updateRefreshToken(String loginId, String refreshToken) {
         redisTemplate.opsForValue()
                 .set("RT:" + loginId, refreshToken, Duration.ofSeconds(refreshTokenExpiration));
     }
 
-    @Transactional
     public void logout(HttpServletRequest request, HttpServletResponse response, String loginId) {
         extractAccessToken(request).ifPresent(accessToken -> {
             try {

--- a/src/main/java/com/example/playlist/global/util/RedisUtil.java
+++ b/src/main/java/com/example/playlist/global/util/RedisUtil.java
@@ -1,7 +1,6 @@
 package com.example.playlist.global.util;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
@@ -9,7 +8,6 @@ import java.util.concurrent.TimeUnit;
 
 @Component
 @RequiredArgsConstructor
-@Slf4j
 public class RedisUtil {
 
     private final StringRedisTemplate stringRedisTemplate;
@@ -28,7 +26,6 @@ public class RedisUtil {
 
     public void setDataExpire(String key, String value, long time) {
         stringRedisTemplate.opsForValue().set(key, value, time, TimeUnit.SECONDS);
-        log.info("Set key={} value={} expire={}s", key, value, time);
     }
 
     public Long getExpire(String key, TimeUnit timeUnit) {

--- a/src/main/java/com/example/playlist/mail/controller/MailController.java
+++ b/src/main/java/com/example/playlist/mail/controller/MailController.java
@@ -9,6 +9,7 @@ import com.example.playlist.mail.exception.MailSuccessCode;
 import com.example.playlist.mail.service.MailService;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.mail.MessagingException;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -30,8 +31,11 @@ public class MailController {
             description = "인증 메일을 전송하는 컨트롤러"
     )
     @PostMapping("/send")
-    public ResponseEntity<SuccessResponse> sendMail(@RequestBody @Valid MailRequest request) throws MessagingException {
-        mailService.sendCertificationMail(request);
+    public ResponseEntity<SuccessResponse> sendMail(@RequestBody @Valid MailRequest request,
+                                                     HttpServletRequest httpRequest) throws MessagingException {
+        String clientIp = httpRequest.getHeader("X-Real-IP");
+        if (clientIp == null || clientIp.isBlank()) clientIp = httpRequest.getRemoteAddr();
+        mailService.sendCertificationMail(request, clientIp);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(SuccessResponse.of(MailSuccessCode.MAIL_SUCCESS_SEND));

--- a/src/main/java/com/example/playlist/mail/service/MailService.java
+++ b/src/main/java/com/example/playlist/mail/service/MailService.java
@@ -12,9 +12,11 @@ import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.mail.MailSendException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -30,6 +32,8 @@ public class MailService {
 
     @Value("${spring.mail.username}")
     String sendEmail;
+
+    private static final int MAIL_RATE_LIMIT = 5; // IP당 분당 최대 5회
 
 
     public MimeMessage createCodeEmail(String email, String code) throws MessagingException {
@@ -54,7 +58,15 @@ public class MailService {
         return UUID.randomUUID().toString().substring(0, 6);
     }
 
-    public String sendCertificationMail(MailRequest mailRequest) throws MessagingException {
+    public String sendCertificationMail(MailRequest mailRequest, String clientIp) throws MessagingException {
+        String key = "mail:ratelimit:" + clientIp;
+        String countStr = redisUtil.getData(key);
+        int count = countStr == null ? 0 : Integer.parseInt(countStr);
+        if (count >= MAIL_RATE_LIMIT) {
+            throw new ResponseStatusException(HttpStatus.TOO_MANY_REQUESTS, "요청이 너무 많습니다. 1분 후 다시 시도해주세요.");
+        }
+        redisUtil.setDataExpire(key, String.valueOf(count + 1), 60);
+
         memberMapper.findByEmail(mailRequest.getEmail()).ifPresent(member -> {
             throw new MailException(MailErrorCode.EMAIL_ALREADY_EXIST);
         });

--- a/src/main/java/com/example/playlist/playlist/controller/PlaylistController.java
+++ b/src/main/java/com/example/playlist/playlist/controller/PlaylistController.java
@@ -38,10 +38,8 @@ public class PlaylistController {
     }
 
     private String getClientIp(HttpServletRequest request) {
-        String ip = request.getHeader("X-Forwarded-For");
-        if (ip != null && !ip.isBlank()) {
-            return ip.split(",")[0].trim();
-        }
+        String ip = request.getHeader("X-Real-IP");
+        if (ip != null && !ip.isBlank()) return ip;
         return request.getRemoteAddr();
     }
 

--- a/src/main/java/com/example/playlist/playlist/service/PlaylistService.java
+++ b/src/main/java/com/example/playlist/playlist/service/PlaylistService.java
@@ -65,7 +65,6 @@ public class PlaylistService {
         String userToken = getSpotifyUserToken(loginId);
 
         String spotifyPlaylistId = spotifyService.createPlaylist(req.getPlaylistName(), userToken);
-        log.info("[Playlist] 새 플레이리스트 생성됨 - spotifyPlaylistId={}", spotifyPlaylistId);
 
         List<String> trackUris = req.getTracks().stream()
                 .map(SpotifyTrackSaveRequest::getSpotifyTrackUri)


### PR DESCRIPTION
## 개요

1. IP 스푸핑을 통한 Rate Limit 우회 보안 취약점 수정
2. 메일 API 무제한 호출 차단
3. 잘못된 어노테이션 및 노이즈성 로그 정리
4. 곡 수집 중복 호출로 인한 Gemini API 비용 낭비 수정
5. Gemini 프롬프트 입력 토큰 최적화

---

## 1. IP 스푸핑을 통한 Rate Limit 우회 (보안)

### 원인
`X-Forwarded-For` 헤더는 클라이언트가 요청 시 임의로 설정할 수 있는 HTTP 헤더입니다. 기존 코드는 이 헤더를 그대로 신뢰해 Rate Limit의 키로 사용하고 있었습니다.

```java
// 기존 - 클라이언트가 헤더 조작 가능
String ip = request.getHeader("X-Forwarded-For");
```

### 문제점
공격자가 요청마다 `X-Forwarded-For` 값을 바꾸면 매번 다른 IP로 인식됩니다.
```bash
curl -H "X-Forwarded-For: 1.2.3.4" https://api/gemini/playlist  # 1회
curl -H "X-Forwarded-For: 5.6.7.8" https://api/gemini/playlist  # 또 1회 (무한 반복)
```
결과적으로 Gemini API Rate Limit이 완전히 무력화되어 API 비용 과다 청구가 재발할 수 있습니다.

### 해결 방법
`X-Real-IP` 헤더로 교체했습니다.

```java
// 변경 후 - Nginx가 서버에서 직접 주입, 클라이언트 조작 불가
String ip = request.getHeader("X-Real-IP");
if (ip != null && !ip.isBlank()) return ip;
return request.getRemoteAddr();
```

Nginx 설정에 `proxy_set_header X-Real-IP $remote_addr;`가 이미 적용되어 있어, Nginx가 TCP 연결 단에서 확인한 실제 클라이언트 IP를 헤더에 주입합니다. 클라이언트가 `X-Real-IP` 헤더를 직접 설정해도 Nginx가 덮어씁니다.

### 다른 해결 방법과 비교
| 방법 | 장점 | 단점 | 선택 여부 |
|---|---|---|---|
| `X-Real-IP` 사용 | 코드만 수정, 간단 | Nginx 설정 확인 필요 | ✅ 선택 |
| `RemoteAddr`만 사용 | 가장 안전 | Nginx 뒤에서는 항상 127.0.0.1 → 전체 유저가 동일 IP로 처리됨 | ❌ |
| Nginx `set_real_ip_from` 설정 | Nginx 레벨에서 강제 | 서버 설정 파일 수정 필요 | 가능하지만 불필요 (X-Real-IP로 충분) |

### 적용 범위
- `GeminiController.getClientIp()`
- `PlaylistController.getClientIp()`
- `MailController` (신규 추가)

---

## 2. 메일 발송 API 인증 없이 무제한 호출 가능 (보안)

### 원인
`POST /mail/send`는 `SecurityConfig`에서 `permitAll()`로 설정되어 있고, Rate Limit이 없었습니다.

### 문제점
누구든 인증 없이 아무 이메일 주소로 무한 발송 요청이 가능합니다. 스팸 도구로 악용되거나 메일 발송 비용이 과다 발생할 수 있습니다.

### 해결 방법
IP 기반 Rate Limit을 추가했습니다 (IP당 분당 5회, Redis TTL 60초).

```java
String key = "mail:ratelimit:" + clientIp;
int count = countStr == null ? 0 : Integer.parseInt(countStr);
if (count >= MAIL_RATE_LIMIT) {
    throw new ResponseStatusException(HttpStatus.TOO_MANY_REQUESTS, "요청이 너무 많습니다. 1분 후 다시 시도해주세요.");
}
redisUtil.setDataExpire(key, String.valueOf(count + 1), 60);
```

Gemini Rate Limit과 동일한 패턴으로 일관성 있게 구현했습니다.

---

## 3. Redis 연산에 @Transactional 적용 오류 (코드 품질)

### 원인
`JwtUtil`의 `saveRefreshToken`, `updateRefreshToken`, `logout` 메서드에 `@Transactional`이 붙어 있었습니다.

### 문제점
`@Transactional`은 Spring의 DB 트랜잭션 관리 대상입니다. Redis는 이 트랜잭션에 참여하지 않으므로 어노테이션이 아무런 효과가 없고, 트랜잭션이 보장된다는 잘못된 인식을 줄 수 있습니다.

### 해결 방법
`@Transactional` 어노테이션 3개와 연관 import를 모두 제거했습니다.

---

## 4. 곡 수집 중복 호출로 인한 Gemini API 비용 낭비 (비용)

### 원인
`collectTracksAsync()` 내부에 RUNNING 상태 체크가 없었습니다.

```java
// 기존 - 호출할 때마다 무조건 새 스레드 시작
public void collectTracksAsync(String decade) {
    statusMap.put(decade, new CollectStatus("RUNNING", ...));
    CompletableFuture.runAsync(() -> collectTracks(decade));
}
```

### 문제점
3번 호출 시 3개의 백그라운드 스레드가 동시에 동작하며 각각 Gemini를 최대 10회 호출합니다.

```
1번 호출 → 스레드A: Gemini 최대 10회
2번 호출 → 스레드B: Gemini 최대 10회  ← A가 실행 중인데 또 시작
3번 호출 → 스레드C: Gemini 최대 10회  ← A, B가 실행 중인데 또 시작
                    ───────────────────
                    총 최대 30회 Gemini 호출
```

세 스레드가 같은 시점에 DB를 읽으면 `seenTitles`가 동일해 Gemini에게 같은 곡을 중복 추천받고, iTunes 호출도 3배로 낭비됩니다. 실제로 수집 3회 호출 시 3,700원 비용이 발생했습니다.

### 해결 방법
RUNNING 상태 체크를 추가해 중복 실행을 차단합니다.

```java
public void collectTracksAsync(String decade) {
    CollectStatus current = statusMap.get(decade);
    if (current != null && "RUNNING".equals(current.status())) {
        throw new IllegalStateException("이미 수집이 진행 중입니다. 완료 후 다시 시도해주세요.");
    }
    statusMap.put(decade, new CollectStatus("RUNNING", ...));
    CompletableFuture.runAsync(() -> collectTracks(decade));
}
```

중복 호출 시 409 Conflict 반환:
```json
{
  "message": "이미 수집이 진행 중입니다. 완료 후 다시 시도해주세요.",
  "decade": "2020"
}
```

---

## 5. Gemini 프롬프트 입력 토큰 무한 증가 (비용)

### 원인
Gemini에게 추천 요청 시 DB에 저장된 전체 제목을 제외 목록으로 프롬프트에 포함하고 있었습니다.

```java
// 기존 - DB 곡 수에 비례해 프롬프트 길이 증가
List<String> seenTitles = new ArrayList<>(quizTrackMapper.findTitlesByDecade(decade));
// DB에 200곡 → 200개 제목이 매 Gemini 호출 프롬프트에 포함
```

### 문제점
DB에 곡이 쌓일수록 매 Gemini 호출마다 입력 토큰이 선형으로 증가합니다. 또한 실제 중복 방지는 `existsByItunesTrackId`에서 이미 처리되고 있어 프롬프트의 제외 목록은 단순 힌트에 불과했습니다.

### 해결 방법
DB 제목은 프롬프트에서 제거하고, 이번 수집 세션 내에서 추천받은 곡만 제외 목록으로 유지합니다.

```java
// 변경 후 - 이번 수집 세션에서 추천받은 곡만 제외 (최대 150개 고정)
List<String> seenTitles = new ArrayList<>();
// 실제 중복 방지는 existsByItunesTrackId 에서 처리
```

| | 변경 전 | 변경 후 |
|---|---|---|
| 제외 목록 크기 | DB 곡 수에 비례해 무한 증가 | 이번 수집 세션 내 추천곡만 (최대 150개 고정) |
| Gemini 입력 토큰 | DB가 쌓일수록 증가 | 항상 일정 |
| 중복 방지 | 프롬프트 힌트 + iTunes TrackId 체크 | iTunes TrackId 체크 (실제 방지는 이게 담당) |

세션 내 중복 추천은 `seenTitles.add(song.title())`로 루프 내에서 계속 누적되므로 같은 수집 중 동일 곡이 두 번 추천되는 것은 여전히 방지됩니다.

---

## 6. 불필요 로그 제거 (운영 품질)

### 제거된 로그 목록
| 파일 | 제거 로그 | 이유 |
|---|---|---|
| `RedisUtil` | `Set key={} value={} expire={}s` | Redis 키/값이 로그에 노출, 모든 Redis 쓰기마다 찍힘 |
| `JwtUtil` | `TempToken 쿠키 설정 완료` | 모든 신규 소셜 로그인마다 찍히는 노이즈 |
| `JwtUtil` | `Access, RefreshToken 쿠키 설정 완료` | 동일 |
| `JwtUtil` | `loginId 추출 실패` | 토큰 파싱 실패는 정상 흐름, 불필요 |
| `JwtUtil` | `로그아웃 된 토큰입니다` | 매 요청 인증마다 찍힐 수 있는 노이즈 |
| `JwtUtil` | `유효하지 않은 Token` | 잘못된 토큰 요청 시 스팸성 로그 |
| `JwtUtil` | `RefreshToken 저장 - loginId={}` | 모든 로그인마다 찍히는 노이즈 |
| `JwtFilter` | `AccessToken 재발급` | 유저 정보 없이 찍혀 컨텍스트 없는 로그 |
| `GameService` | `[Game] DB 조회 - title={}, artist={}` | 모든 퀴즈 요청마다 곡 정보 노출 |
| `PlaylistService` | `새 플레이리스트 생성됨` | 완료 로그와 중복 |

### 유지된 로그
- `log.error` — 외부 API 실패, 예외 핸들러
- `log.warn` — Spotify 검색 없음, 토큰 파싱 실패 등 의미 있는 경고
- `log.info` — OAuth2 로그인/신규 회원 생성, 플레이리스트 생성/삭제 완료, 수집 진행 상황

---

## 7. 미사용 어노테이션 및 중복 import 제거 (코드 품질)

- `RedisUtil` — `@Slf4j` 제거
- `JwtFilter` — `@Slf4j` 제거
- `GameService` — `@Slf4j` 제거
- `GameController` — `import GameCollectService` 중복 선언 제거

---

## 전체 결과 요약

| 항목 | 이전 | 이후 |
|---|---|---|
| Gemini Rate Limit | IP 스푸핑으로 우회 가능 | Nginx 레벨 실제 IP 사용, 우회 불가 |
| 메일 API | 무제한 호출 가능 | IP당 분당 5회 제한 |
| Redis @Transactional | 의미 없이 존재 | 제거 |
| 곡 수집 중복 호출 | 동시에 여러 스레드 실행, 비용 N배 | RUNNING 체크로 차단, 409 반환 |
| Gemini 입력 토큰 | DB 규모에 비례해 증가 | 항상 일정 (세션 내 추천곡만 포함) |
| 로그 노이즈 | 매 요청마다 불필요 로그 다수 | 의미 있는 로그만 유지 |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)