### PR TITLE
퀴즈 정답 서버 검증 전환 + Gemini thinking 모델 비용 문제 수정

### DIFF
--- a/src/main/java/com/example/playlist/game/controller/GameController.java
+++ b/src/main/java/com/example/playlist/game/controller/GameController.java
@@ -1,5 +1,7 @@
 package com.example.playlist.game.controller;
 
+import com.example.playlist.game.dto.QuizAnswerRequest;
+import com.example.playlist.game.dto.QuizAnswerResponse;
 import com.example.playlist.game.dto.QuizTrackResponse;
 import com.example.playlist.game.service.GameCollectService;
 import com.example.playlist.game.service.GameService;
@@ -26,6 +28,17 @@ public class GameController {
             @RequestParam String decade
     ) {
         return ResponseEntity.ok(gameService.getQuizTrack(decade));
+    }
+
+    @Operation(
+            summary = "퀴즈 정답 제출",
+            description = "quizId와 사용자 답변을 제출하면 정답 여부와 실제 제목/아티스트를 반환. quizId 발급 후 5분 내 제출 필요."
+    )
+    @PostMapping("/game/quiz/answer")
+    public ResponseEntity<QuizAnswerResponse> submitAnswer(
+            @RequestBody QuizAnswerRequest request
+    ) {
+        return ResponseEntity.ok(gameService.checkAnswer(request));
     }
 
     @Operation(

--- a/src/main/java/com/example/playlist/game/dto/QuizAnswerRequest.java
+++ b/src/main/java/com/example/playlist/game/dto/QuizAnswerRequest.java
@@ -1,0 +1,6 @@
+package com.example.playlist.game.dto;
+
+public record QuizAnswerRequest(
+        String quizId,
+        String answer
+) {}

--- a/src/main/java/com/example/playlist/game/dto/QuizAnswerResponse.java
+++ b/src/main/java/com/example/playlist/game/dto/QuizAnswerResponse.java
@@ -1,0 +1,8 @@
+package com.example.playlist.game.dto;
+
+public record QuizAnswerResponse(
+        boolean correct,
+        String title,
+        String artist,
+        String albumImageUrl
+) {}

--- a/src/main/java/com/example/playlist/game/dto/QuizTrackResponse.java
+++ b/src/main/java/com/example/playlist/game/dto/QuizTrackResponse.java
@@ -1,39 +1,7 @@
 package com.example.playlist.game.dto;
 
-import com.example.playlist.game.entity.QuizTrack;
-
 public record QuizTrackResponse(
-        String trackId,
+        String quizId,
         String previewUrl,
-        String title,
-        String artist,
-        String albumImageUrl,
-        String titleNormalized,        // 한국어 제목 정규화 (괄호 제거 + 공백 제거 + 소문자)
-        String titleNormalizedAlias,   // 영어 제목 정규화 (null 가능)
-        String artistNormalized,       // 한국어 아티스트 정규화
-        String artistNormalizedAlias   // 영어 아티스트 정규화 (null 가능)
-) {
-    public static QuizTrackResponse fromEntity(QuizTrack track) {
-        return new QuizTrackResponse(
-                track.getItunesTrackId(),
-                track.getPreviewUrl(),
-                track.getTitle(),
-                track.getArtist(),
-                track.getAlbumImageUrl(),
-                normalize(track.getTitle()),
-                normalize(track.getTitleAlias()),
-                normalize(track.getArtist()),
-                normalize(track.getArtistAlias())
-        );
-    }
-
-    private static String normalize(String value) {
-        if (value == null) return null;
-        return value
-                .replaceAll("\\(.*?\\)", "")   // (영어 부제) 제거
-                .replaceAll("\\[.*?\\]", "")   // [영어 부제] 제거
-                .replaceAll("\\s+", "")
-                .toLowerCase()
-                .trim();
-    }
-}
+        String albumImageUrl
+) {}

--- a/src/main/java/com/example/playlist/game/entity/QuizTrack.java
+++ b/src/main/java/com/example/playlist/game/entity/QuizTrack.java
@@ -1,12 +1,16 @@
 package com.example.playlist.game.entity;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class QuizTrack {
     private Long id;
     private String title;

--- a/src/main/java/com/example/playlist/game/service/GameCollectService.java
+++ b/src/main/java/com/example/playlist/game/service/GameCollectService.java
@@ -11,6 +11,7 @@ import com.google.genai.types.GenerateContentConfig;
 import com.google.genai.types.GenerateContentResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 
@@ -26,6 +27,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class GameCollectService {
 
     private final Client geminiClient;
+    @Qualifier("gameCollectConfig")
     private final GenerateContentConfig geminiConfig;
     private final WebClient itunesWebClient;
     private final QuizTrackMapper quizTrackMapper;
@@ -143,7 +145,7 @@ public class GameCollectService {
                 """, decadeLabel, BATCH_SIZE, exclusionList);
 
         GenerateContentResponse response = geminiClient.models.generateContent(
-                "gemini-3-flash-preview", prompt, geminiConfig);
+                "gemini-1.5-flash", prompt, geminiConfig);
 
         String json = response.text().trim()
                 .replaceAll("```json", "").replaceAll("```", "").trim();

--- a/src/main/java/com/example/playlist/game/service/GameService.java
+++ b/src/main/java/com/example/playlist/game/service/GameService.java
@@ -1,22 +1,73 @@
 package com.example.playlist.game.service;
 
+import com.example.playlist.game.dto.QuizAnswerRequest;
+import com.example.playlist.game.dto.QuizAnswerResponse;
 import com.example.playlist.game.dto.QuizTrackResponse;
 import com.example.playlist.game.entity.QuizTrack;
 import com.example.playlist.game.repository.QuizTrackMapper;
+import com.example.playlist.global.util.RedisUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.UUID;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class GameService {
 
     private final QuizTrackMapper quizTrackMapper;
+    private final RedisUtil redisUtil;
+    private final ObjectMapper objectMapper;
+
+    private static final long QUIZ_TTL_SECONDS = 5 * 60; // 5분
 
     public QuizTrackResponse getQuizTrack(String decade) {
         QuizTrack track = quizTrackMapper.findRandomByDecade(decade);
         if (track == null) {
             throw new IllegalStateException("해당 연대의 곡이 없습니다. 먼저 수집을 진행해주세요.");
         }
-        return QuizTrackResponse.fromEntity(track);
+
+        String quizId = UUID.randomUUID().toString();
+        try {
+            redisUtil.setDataExpire("quiz:" + quizId, objectMapper.writeValueAsString(track), QUIZ_TTL_SECONDS);
+        } catch (Exception e) {
+            log.warn("[Quiz] Redis 저장 실패 - quizId={}", quizId, e);
+            throw new IllegalStateException("퀴즈 생성에 실패했습니다.");
+        }
+
+        return new QuizTrackResponse(quizId, track.getPreviewUrl(), track.getAlbumImageUrl());
+    }
+
+    public QuizAnswerResponse checkAnswer(QuizAnswerRequest request) {
+        String json = redisUtil.getData("quiz:" + request.quizId());
+        if (json == null) {
+            throw new IllegalArgumentException("만료되었거나 존재하지 않는 퀴즈입니다.");
+        }
+
+        QuizTrack track;
+        try {
+            track = objectMapper.readValue(json, QuizTrack.class);
+        } catch (Exception e) {
+            throw new IllegalStateException("퀴즈 데이터를 읽을 수 없습니다.");
+        }
+
+        String userAnswer = normalize(request.answer());
+        boolean correct = userAnswer.equals(normalize(track.getTitle()))
+                || (track.getTitleAlias() != null && userAnswer.equals(normalize(track.getTitleAlias())));
+
+        return new QuizAnswerResponse(correct, track.getTitle(), track.getArtist(), track.getAlbumImageUrl());
+    }
+
+    private String normalize(String value) {
+        if (value == null) return "";
+        return value
+                .replaceAll("\\(.*?\\)", "")
+                .replaceAll("\\[.*?\\]", "")
+                .replaceAll("\\s+", "")
+                .toLowerCase()
+                .trim();
     }
 }

--- a/src/main/java/com/example/playlist/gemini/service/GeminiService.java
+++ b/src/main/java/com/example/playlist/gemini/service/GeminiService.java
@@ -30,7 +30,7 @@ public class GeminiService {
         try {
             GenerateContentResponse response =
                     geminiClient.models.generateContent(
-                            "gemini-3-flash-preview",
+                            "gemini-1.5-flash",
                             request.toPrompt(),
                             geminiConfig
                     );

--- a/src/main/java/com/example/playlist/global/config/GeminiConfig.java
+++ b/src/main/java/com/example/playlist/global/config/GeminiConfig.java
@@ -8,6 +8,7 @@ import com.google.genai.types.Schema;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 
 import java.util.Map;
 
@@ -24,6 +25,8 @@ public class GeminiConfig {
                 .build();
     }
 
+    /** 플레이리스트 추천용 설정 (playlistTitle + songs[title, artist]) */
+    @Primary
     @Bean
     public GenerateContentConfig generateContentConfig() {
         return GenerateContentConfig.builder()
@@ -33,9 +36,9 @@ public class GeminiConfig {
                             정확한 분위기의 곡만 추천해야 한다.
                             절대 JSON 형식을 깨지 마라.
                 """)))
-                .temperature(0.5f) // 높을수록 창의성 높은 대답
-                .topP(0.8f) //상위 80%만 사용
-                .responseMimeType("application/json") //출력 형태
+                .temperature(0.5f)
+                .topP(0.8f)
+                .responseMimeType("application/json")
                 .responseSchema(Schema.builder()
                         .type("object")
                         .properties(Map.of(
@@ -55,6 +58,28 @@ public class GeminiConfig {
                 .build();
     }
 
-
-
+    /** 곡 수집용 설정 (songs[title, artist, searchQuery]) */
+    @Bean
+    public GenerateContentConfig gameCollectConfig() {
+        return GenerateContentConfig.builder()
+                .temperature(0.7f)
+                .responseMimeType("application/json")
+                .responseSchema(Schema.builder()
+                        .type("object")
+                        .properties(Map.of(
+                                "songs", Schema.builder()
+                                        .type("array")
+                                        .items(Schema.builder()
+                                                .type("object")
+                                                .properties(Map.of(
+                                                        "title", Schema.builder().type("string").build(),
+                                                        "artist", Schema.builder().type("string").build(),
+                                                        "searchQuery", Schema.builder().type("string").build()
+                                                ))
+                                                .build())
+                                        .build()
+                        )).build()
+                )
+                .build();
+    }
 }


### PR DESCRIPTION
## 개요

두 가지 독립적인 문제를 수정합니다.

---

## 1. 퀴즈 정답 노출 취약점 수정

### 원인
`GET /game/quiz` 응답에 `title`, `artist`, `titleNormalized`, `artistNormalized` 등 정답 정보가 그대로 포함되어 있었음.
클라이언트 사이드에서 정답 검증을 하는 구조였기 때문에 브라우저 개발자 도구로 응답을 보면 정답을 바로 확인 가능했음.

### 문제점
퀴즈 게임의 의미가 없어짐. 누구든 개발자 도구 Network 탭에서 정답을 볼 수 있음.

### 해결 방법
서버 사이드 정답 검증으로 전환.

**흐름:**
1. `GET /game/quiz?decade=2020`
   - DB에서 랜덤 트랙 조회
   - UUID `quizId` 발급 → Redis에 트랙 전체 정보를 `quiz:{quizId}` 키로 **5분 TTL** 저장
   - 응답: `{ quizId, previewUrl, albumImageUrl }` 만 반환 (정답 없음)

2. `POST /game/quiz/answer`
   - `{ quizId, answer }` 수신
   - Redis에서 `quizId`로 트랙 조회 → 없으면 만료/무효 에러
   - 사용자 답변을 서버에서 정규화(소문자, 괄호/공백 제거) 후 한국어 제목 & 영어 제목 alias 둘 다 비교
   - 응답: `{ correct, title, artist, albumImageUrl }`

### 변경 파일
| 파일 | 변경 내용 |
|------|-----------|
| `QuizTrackResponse` | `quizId`, `previewUrl`, `albumImageUrl` 3개 필드만 남김 |
| `QuizAnswerRequest` | 신규 DTO (`quizId`, `answer`) |
| `QuizAnswerResponse` | 신규 DTO (`correct`, `title`, `artist`, `albumImageUrl`) |
| `GameService` | Redis 저장/조회 + 정규화 정답 비교 로직 추가 |
| `GameController` | `POST /game/quiz/answer` 엔드포인트 추가 |
| `QuizTrack` | `@NoArgsConstructor` + `@AllArgsConstructor` 추가 (Jackson 역직렬화 지원) |

---

## 2. Gemini thinking 모델로 인한 과금 폭증 수정

### 원인
`gemini-3-flash-preview`는 **thinking 모델** (내부 추론 토큰 사용).
실제 로그에서 확인된 토큰 구성:
- `promptTokenCount: 630`
- `candidatesTokenCount: 2,609`
- `thoughtsTokenCount: 62,912` ← 내부 추론 토큰, **여기서 비용 폭증**
- `finishReason: MAX_TOKENS` ← 토큰 한도 초과

### 문제점
1. 62,912 thinking 토큰이 매 호출마다 과금됨
2. MAX_TOKENS로 응답이 잘려 garbage JSON 출력 ("영웅 (Kick It)127" 반복)
3. JSON 파싱 실패 → `catch (Exception e)` → attempt 루프 재시도
4. 연대별 **5~8번** Gemini 재호출 발생
5. 수집 1회에 **1,500원 이상** 과금

### 해결 방법

**모델 교체**: `gemini-3-flash-preview` → `gemini-1.5-flash` (non-thinking 모델)
- thinking 토큰 없음 → 정상적인 토큰만 과금
- MAX_TOKENS 초과 없음 → 응답 완전히 반환 → JSON 파싱 성공 → 1~2회 호출로 완료

**잘못된 Schema 주입 수정**: `GameCollectService`가 플레이리스트용 config(`playlistTitle + songs[title, artist]`)를 주입받고 있었음.
곡 수집 전용 `gameCollectConfig` 빈을 별도 추가 (`songs[title, artist, searchQuery]` 스키마).
`@Qualifier("gameCollectConfig")`로 올바른 빈 주입.

### 변경 파일
| 파일 | 변경 내용 |
|------|-----------|
| `GeminiConfig` | `gameCollectConfig` 빈 추가 (수집 전용 스키마), `@Primary` 추가 |
| `GameCollectService` | `@Qualifier("gameCollectConfig")`, 모델 → `gemini-1.5-flash` |
| `GeminiService` | 모델 → `gemini-1.5-flash` |

---

## 결과
- 퀴즈 정답 API 응답에서 완전히 제거 → 개발자 도구로 정답 확인 불가
- Gemini 과금 정상화 (수집 1회 기준 수백 원 → 수십 원 수준으로 감소 예상)

🤖 Generated with [Claude Code](https://claude.com/claude-code)