### PR TITLE
관리자 통계 페이지: 일별 방문자 수 & AI 호출 횟수 조회

### DIFF
--- a/src/main/java/com/example/playlist/admin/controller/AdminStatsController.java
+++ b/src/main/java/com/example/playlist/admin/controller/AdminStatsController.java
@@ -1,0 +1,32 @@
+package com.example.playlist.admin.controller;
+
+import com.example.playlist.admin.dto.DailyStatsResponse;
+import com.example.playlist.admin.service.AdminStatsService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/admin/stats")
+@RequiredArgsConstructor
+public class AdminStatsController {
+
+    private final AdminStatsService adminStatsService;
+
+    @Operation(
+            summary = "[Admin] 일별 방문자 수 & AI 호출 횟수 조회",
+            description = "오늘부터 days일 전까지의 방문자 수(유니크 IP)와 AI 추천 호출 횟수를 반환합니다."
+    )
+    @GetMapping("/visitors")
+    public ResponseEntity<List<DailyStatsResponse>> getStats(
+            @RequestParam(defaultValue = "7") int days
+    ) {
+        return ResponseEntity.ok(adminStatsService.getStats(days));
+    }
+}

--- a/src/main/java/com/example/playlist/admin/dto/DailyStatsResponse.java
+++ b/src/main/java/com/example/playlist/admin/dto/DailyStatsResponse.java
@@ -1,0 +1,7 @@
+package com.example.playlist.admin.dto;
+
+public record DailyStatsResponse(
+        String date,
+        long visitorCount,
+        long aiCallCount
+) {}

--- a/src/main/java/com/example/playlist/admin/service/AdminStatsService.java
+++ b/src/main/java/com/example/playlist/admin/service/AdminStatsService.java
@@ -1,0 +1,36 @@
+package com.example.playlist.admin.service;
+
+import com.example.playlist.admin.dto.DailyStatsResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AdminStatsService {
+
+    private final StringRedisTemplate redisTemplate;
+
+    public List<DailyStatsResponse> getStats(int days) {
+        List<DailyStatsResponse> result = new ArrayList<>();
+
+        for (int i = 0; i < days; i++) {
+            LocalDate date = LocalDate.now().minusDays(i);
+
+            Long visitorCount = redisTemplate.opsForSet().size("visitor:" + date);
+            String aiCallStr = redisTemplate.opsForValue().get("ai:calls:" + date);
+
+            result.add(new DailyStatsResponse(
+                    date.toString(),
+                    visitorCount != null ? visitorCount : 0L,
+                    aiCallStr != null ? Long.parseLong(aiCallStr) : 0L
+            ));
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/com/example/playlist/gemini/service/GeminiService.java
+++ b/src/main/java/com/example/playlist/gemini/service/GeminiService.java
@@ -11,7 +11,11 @@ import com.google.genai.Client;
 import com.google.genai.types.GenerateContentConfig;
 import com.google.genai.types.GenerateContentResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.LocalDate;
 
 @Service
 @RequiredArgsConstructor
@@ -21,8 +25,9 @@ public class GeminiService {
     private final GenerateContentConfig geminiConfig;
     private final ObjectMapper objectMapper;
     private final RedisUtil redisUtil;
+    private final StringRedisTemplate redisTemplate;
 
-    private static final int RATE_LIMIT_PER_MINUTE = 5;  // IP당 분당 최대 요청 수
+    private static final int RATE_LIMIT_PER_MINUTE = 5;
 
     public GeminiResponse CreatePlaylist(GeminiRequest request, String clientIp) throws JsonProcessingException {
         checkRateLimit(clientIp);
@@ -35,12 +40,20 @@ public class GeminiService {
                             geminiConfig
                     );
 
+            incrementAiCallCount();
+
             String jsonText = response.text();
             return objectMapper.readValue(jsonText, GeminiResponse.class);
 
         } catch (com.google.genai.errors.ServerException e) {
             throw new GeminiException(GeminiErrorCode.GEMINI_IS_BUSY);
         }
+    }
+
+    private void incrementAiCallCount() {
+        String key = "ai:calls:" + LocalDate.now();
+        redisTemplate.opsForValue().increment(key);
+        redisTemplate.expire(key, Duration.ofDays(30));
     }
 
     private void checkRateLimit(String clientIp) {

--- a/src/main/java/com/example/playlist/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/playlist/global/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.example.playlist.global.config;
 
 import com.example.playlist.global.filter.JwtFilter;
+import com.example.playlist.global.filter.VisitorFilter;
 import com.example.playlist.global.oauth2.HttpCookieOAuth2AuthorizationRequestRepository;
 import com.example.playlist.global.util.JwtUtil;
 import com.example.playlist.member.oauth2.CustomOAuth2UserService;
@@ -33,6 +34,7 @@ public class SecurityConfig {
 
     private final JwtUtil jwtUtil;
     private final JwtFilter jwtFilter;
+    private final VisitorFilter visitorFilter;
     private final CustomOAuth2UserService customOAuth2UserService;
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
     private final OAuth2FailureHandler oAuth2FailureHandler;
@@ -92,7 +94,8 @@ public class SecurityConfig {
                         .failureHandler(oAuth2FailureHandler)
                 );
         http
-                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterAfter(visitorFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/example/playlist/global/filter/VisitorFilter.java
+++ b/src/main/java/com/example/playlist/global/filter/VisitorFilter.java
@@ -1,0 +1,34 @@
+package com.example.playlist.global.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.LocalDate;
+
+@Component
+@RequiredArgsConstructor
+public class VisitorFilter extends OncePerRequestFilter {
+
+    private final StringRedisTemplate redisTemplate;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String ip = request.getHeader("X-Real-IP");
+        if (ip == null || ip.isBlank()) ip = request.getRemoteAddr();
+
+        String key = "visitor:" + LocalDate.now();
+        redisTemplate.opsForSet().add(key, ip);
+        redisTemplate.expire(key, Duration.ofDays(30));
+
+        filterChain.doFilter(request, response);
+    }
+}


### PR DESCRIPTION
## 무엇을 만들었나요?

관리자가 서비스 현황을 한눈에 파악할 수 있는 통계 API를 추가했습니다.

---

## 어떻게 동작하나요?

### 📊 응답 예시

```
GET /admin/stats/visitors?days=7
```

```json
[
  { "date": "2026-04-23", "visitorCount": 42, "aiCallCount": 15 },
  { "date": "2026-04-22", "visitorCount": 38, "aiCallCount": 9 },
  ...
]
```

- `visitorCount` : 해당 날짜에 접속한 **유니크 방문자 수** (같은 IP는 1명으로 카운트)
- `aiCallCount` : 해당 날짜의 **AI 플레이리스트 추천 호출 수**
- `days` 파라미터로 조회 기간 조절 가능 (기본값: 7일)

---

## 내부 동작 흐름

```
사용자 요청 → VisitorFilter → IP 추출(X-Real-IP)
                            → Redis SET에 SADD("visitor:2026-04-23", "1.2.3.4")
                              (같은 IP 중복 자동 제거 / TTL 30일)

AI 추천 요청 → GeminiService.CreatePlaylist()
             → Gemini 응답 성공 시 Redis INCR("ai:calls:2026-04-23")

관리자 조회 → /admin/stats/visitors
           → Redis에서 날짜별 SET SIZE + 카운터 읽어 반환
```

---

## 변경된 파일

| 파일 | 역할 |
|------|------|
| `VisitorFilter` (신규) | 모든 요청에서 IP를 추출해 Redis Set에 날짜별로 저장 |
| `GeminiService` | AI 추천 성공 시 날짜별 호출 카운터 증가 |
| `AdminStatsController` (신규) | `GET /admin/stats/visitors` 엔드포인트 |
| `AdminStatsService` (신규) | Redis에서 날짜별 방문자/AI 호출 수 집계 |
| `DailyStatsResponse` (신규) | 응답 DTO (`date`, `visitorCount`, `aiCallCount`) |
| `SecurityConfig` | VisitorFilter를 필터 체인에 등록 |

---

## 접근 권한

`/admin/**` 경로는 기존 설정대로 `ROLE_ADMIN`만 접근 가능합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)