### PR TITLE
퀴즈 정답 검증 개선: 아티스트 별칭 매칭 + 특수문자 처리

### DIFF
--- a/src/main/java/com/example/playlist/game/dto/QuizAnswerRequest.java
+++ b/src/main/java/com/example/playlist/game/dto/QuizAnswerRequest.java
@@ -2,5 +2,6 @@ package com.example.playlist.game.dto;
 
 public record QuizAnswerRequest(
         String quizId,
-        String answer
+        String titleAnswer,
+        String artistAnswer
 ) {}

--- a/src/main/java/com/example/playlist/game/dto/QuizAnswerResponse.java
+++ b/src/main/java/com/example/playlist/game/dto/QuizAnswerResponse.java
@@ -2,6 +2,8 @@ package com.example.playlist.game.dto;
 
 public record QuizAnswerResponse(
         boolean correct,
+        boolean titleCorrect,
+        boolean artistCorrect,
         String title,
         String artist,
         String albumImageUrl

--- a/src/main/java/com/example/playlist/game/service/GameService.java
+++ b/src/main/java/com/example/playlist/game/service/GameService.java
@@ -54,20 +54,24 @@ public class GameService {
             throw new IllegalStateException("퀴즈 데이터를 읽을 수 없습니다.");
         }
 
-        String userAnswer = normalize(request.answer());
-        boolean correct = userAnswer.equals(normalize(track.getTitle()))
-                || (track.getTitleAlias() != null && userAnswer.equals(normalize(track.getTitleAlias())));
+        String titleAnswer = normalize(request.titleAnswer());
+        boolean titleCorrect = titleAnswer.equals(normalize(track.getTitle()))
+                || (track.getTitleAlias() != null && titleAnswer.equals(normalize(track.getTitleAlias())));
 
-        return new QuizAnswerResponse(correct, track.getTitle(), track.getArtist(), track.getAlbumImageUrl());
+        String artistAnswer = normalize(request.artistAnswer());
+        boolean artistCorrect = artistAnswer.equals(normalize(track.getArtist()))
+                || (track.getArtistAlias() != null && artistAnswer.equals(normalize(track.getArtistAlias())));
+
+        return new QuizAnswerResponse(titleCorrect && artistCorrect, titleCorrect, artistCorrect,
+                track.getTitle(), track.getArtist(), track.getAlbumImageUrl());
     }
 
     private String normalize(String value) {
         if (value == null) return "";
         return value
-                .replaceAll("\\(.*?\\)", "")
-                .replaceAll("\\[.*?\\]", "")
-                .replaceAll("\\s+", "")
-                .toLowerCase()
-                .trim();
+                .replaceAll("\\(.*?\\)", "")   // 괄호 내용 제거
+                .replaceAll("\\[.*?\\]", "")   // 대괄호 내용 제거
+                .replaceAll("[^\\p{L}\\p{N}]", "") // 특수문자·공백·쉼표 전부 제거
+                .toLowerCase();
     }
 }


### PR DESCRIPTION
## 문제

1. **"피 땀 눈물" 입력 시 오답** → 공백은 제거되지만 쉼표 등 특수문자가 남아 `"피,땀,눈물"` vs `"피땀눈물"` 불일치
2. **"아이브", "BTS" 입력 시 오답** → 아티스트 별칭(`artistAlias`) 비교 로직이 아예 없었음
3. **제목/아티스트 각각 채점 불가** → 단일 `answer` 필드로 어느 쪽이 틀렸는지 알 수 없었음

---

## 해결

### `normalize()` 강화
```
기존: 괄호 제거 + 공백 제거
변경: 괄호 제거 + 특수문자·공백·쉼표 전부 제거 ([^\p{L}\p{N}])
```
- `"피, 땀, 눈물"` → `"피땀눈물"` ✓
- `"Love Dive"` → `"lovedive"` ✓

### 아티스트 별칭 비교 추가
```
title 검증:  titleAnswer == title  OR  titleAnswer == titleAlias
artist 검증: artistAnswer == artist  OR  artistAnswer == artistAlias
```
- `"아이브"` → artistAlias `"아이브"` 매칭 ✓
- `"BTS"` → artistAlias `"BTS"` 매칭 ✓

### 요청/응답 구조 변경

**요청 (`QuizAnswerRequest`)**
```json
// 기존
{ "quizId": "...", "answer": "아이브" }

// 변경
{ "quizId": "...", "titleAnswer": "Love Dive", "artistAnswer": "아이브" }
```

**응답 (`QuizAnswerResponse`)**
```json
// 기존
{ "correct": false, "title": "...", "artist": "...", "albumImageUrl": "..." }

// 변경
{ "correct": true, "titleCorrect": true, "artistCorrect": true, "title": "...", "artist": "...", "albumImageUrl": "..." }
```
`titleCorrect` / `artistCorrect` 분리로 프론트에서 어느 쪽이 틀렸는지 표시 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)