### PR TITLE
feat: 어드민 - 로그인 회원 방문자 추적 추가

### DIFF
--- a/src/main/java/com/example/playlist/admin/dto/DailyStatsResponse.java
+++ b/src/main/java/com/example/playlist/admin/dto/DailyStatsResponse.java
@@ -1,7 +1,10 @@
 package com.example.playlist.admin.dto;
 
+import java.util.Set;
+
 public record DailyStatsResponse(
         String date,
         long visitorCount,
-        long aiCallCount
+        long aiCallCount,
+        Set<String> memberVisitors
 ) {}

--- a/src/main/java/com/example/playlist/admin/service/AdminStatsService.java
+++ b/src/main/java/com/example/playlist/admin/service/AdminStatsService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -23,11 +24,13 @@ public class AdminStatsService {
 
             Long visitorCount = redisTemplate.opsForSet().size("visitor:" + date);
             String aiCallStr = redisTemplate.opsForValue().get("ai:calls:" + date);
+            Set<String> memberVisitors = redisTemplate.opsForSet().members("visitor:member:" + date);
 
             result.add(new DailyStatsResponse(
                     date.toString(),
                     visitorCount != null ? visitorCount : 0L,
-                    aiCallStr != null ? Long.parseLong(aiCallStr) : 0L
+                    aiCallStr != null ? Long.parseLong(aiCallStr) : 0L,
+                    memberVisitors != null ? memberVisitors : Set.of()
             ));
         }
 

--- a/src/main/java/com/example/playlist/global/filter/JwtFilter.java
+++ b/src/main/java/com/example/playlist/global/filter/JwtFilter.java
@@ -8,6 +8,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -18,6 +19,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.time.Duration;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -27,6 +30,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
     private final MemberMapper memberMapper;
+    private final StringRedisTemplate redisTemplate;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
@@ -39,6 +43,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
             if (loginIdOpt.isPresent()) {
                 saveAuthentication(loginIdOpt.get(), role);
+                recordMemberVisit(loginIdOpt.get());
             }
             filterChain.doFilter(request, response);
             return;
@@ -65,6 +70,12 @@ public class JwtFilter extends OncePerRequestFilter {
             }
         }
         filterChain.doFilter(request, response);
+    }
+
+    private void recordMemberVisit(String loginId) {
+        String key = "visitor:member:" + LocalDate.now();
+        redisTemplate.opsForSet().add(key, loginId);
+        redisTemplate.expire(key, Duration.ofDays(30));
     }
 
     public void saveAuthentication(String loginId, String role) {


### PR DESCRIPTION
## Summary

- 로그인한 회원이 API 요청 시 `loginId`를 Redis에 자동 기록
- 어드민 통계 API 응답에 `memberVisitors` 필드 추가
- 어드민 권한으로만 조회 가능 (일반 사용자 접근 불가)

## Changes

- `JwtFilter` — 인증 성공 시 `visitor:member:{날짜}` Redis Set에 `loginId` 저장 (30일 TTL)
- `AdminStatsService` — 날짜별 `memberVisitors` Set 조회 추가
- `DailyStatsResponse` — `memberVisitors: Set<String>` 필드 추가

## 응답 예시

```json
{
  "date": "2026-04-27",
  "visitorCount": 15,
  "aiCallCount": 8,
  "memberVisitors": ["user123", "choi99", "kim01"]
}
```

## Test plan

- [ ] 로그인 후 API 호출 시 `memberVisitors`에 loginId 포함 확인
- [ ] 비로그인 사용자는 `memberVisitors`에 미포함 확인
- [ ] 일반 회원이 어드민 통계 API 호출 시 403 반환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)